### PR TITLE
Handshake-gated connect, per-network transport memory, and naive macOS support

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -48,6 +48,16 @@ jobs:
       - name: Install goversioninfo
         run: go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest
 
+      # cgo-links the prebuilt pangea_naive.lib (native COFF) for the naive
+      # transport. windows-latest ships LLVM; install it only if missing.
+      - name: Ensure LLVM (clang-cl) for naive_cgo
+        shell: pwsh
+        run: |
+          if (-not (Test-Path "C:\Program Files\LLVM\bin\clang-cl.exe")) {
+            choco install llvm --no-progress -y
+          }
+          & "C:\Program Files\LLVM\bin\clang-cl.exe" --version
+
       - name: Install workspace dependencies
         run: npm ci
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pangeavpn/desktop",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "author": {
     "name": "Pangea",

--- a/daemon/cmd/daemon/main.go
+++ b/daemon/cmd/daemon/main.go
@@ -96,6 +96,16 @@ func startDaemonRuntime() (*daemonRuntime, error) {
 	killSwitch := platform.NewKillSwitch()
 	service := api.NewService(machine, logs, configStore, cloakManager, naiveManager, realityManager, hysteria2Manager, snowflakeManager, wgManager, killSwitch)
 
+	// Per-network last-good-transport cache is a best-effort optimization; a
+	// failure to open it just leaves auto-connect walking the full cascade.
+	if memPath, pathErr := platform.TransportMemoryPath(); pathErr != nil {
+		logs.Add(state.LogWarn, state.SourceDaemon, fmt.Sprintf("transport memory disabled: %v", pathErr))
+	} else if memStore, storeErr := state.NewTransportMemoryStore(memPath); storeErr != nil {
+		logs.Add(state.LogWarn, state.SourceDaemon, fmt.Sprintf("transport memory disabled: %v", storeErr))
+	} else {
+		service.SetTransportMemory(memStore)
+	}
+
 	handler := api.NewHandler(token, service)
 	server := &http.Server{
 		Addr:    daemonAddr,

--- a/daemon/cmd/daemon/versioninfo.json
+++ b/daemon/cmd/daemon/versioninfo.json
@@ -3,13 +3,13 @@
     "FileVersion": {
       "Major": 0,
       "Minor": 4,
-      "Patch": 2,
+      "Patch": 3,
       "Build": 0
     },
     "ProductVersion": {
       "Major": 0,
       "Minor": 4,
-      "Patch": 2,
+      "Patch": 3,
       "Build": 0
     },
     "FileFlagsMask": "3f",
@@ -22,13 +22,13 @@
     "Comments": "",
     "CompanyName": "PangeaVPN",
     "FileDescription": "PangeaVPN Daemon",
-    "FileVersion": "0.4.2.0",
+    "FileVersion": "0.4.3.0",
     "InternalName": "PangeaDaemon",
     "LegalCopyright": "Copyright (c) PangeaVPN",
     "OriginalFilename": "PangeaDaemon.exe",
     "PrivateBuild": "",
     "ProductName": "PangeaVPN",
-    "ProductVersion": "0.4.2.0",
+    "ProductVersion": "0.4.3.0",
     "SpecialBuild": ""
   },
   "VarFileInfo": {

--- a/daemon/internal/api/network_key.go
+++ b/daemon/internal/api/network_key.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"net"
+	"sort"
+	"strings"
+)
+
+// currentNetworkKey fingerprints the physical network the host is attached to,
+// so the daemon can remember which transport last worked here and try it first
+// next time. It mirrors the desktop networkWatcher's approach — a stable
+// signature of the non-tunnel interfaces' addresses — but keys IPv6 on the /64
+// prefix so privacy-extension address rotation within one network does not
+// change the key. Returns "" when nothing usable is found; the caller then
+// skips the memory optimization (and the cascade still tries every transport).
+func currentNetworkKey() string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+
+	var parts []string
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		if isTunnelInterfaceName(iface.Name) {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			ip := ipFromAddr(addr)
+			if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsMulticast() {
+				continue
+			}
+			parts = append(parts, iface.Name+":"+networkToken(ip))
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, "|")
+}
+
+// isTunnelInterfaceName reports whether name looks like a VPN/tunnel interface,
+// which must be excluded so the daemon's own tunnel bring-up/tear-down does not
+// change the network key. Matches the desktop networkWatcher's prefixes.
+func isTunnelInterfaceName(name string) bool {
+	lower := strings.ToLower(name)
+	return strings.HasPrefix(lower, "tun") ||
+		strings.HasPrefix(lower, "utun") ||
+		strings.HasPrefix(lower, "wg") ||
+		strings.HasPrefix(lower, "pangea")
+}
+
+// networkToken renders an address into the stable part of the key: the full
+// IPv4 address (a DHCP lease is stable for the network), or the IPv6 /64
+// network prefix (host bits rotate under privacy extensions).
+func networkToken(ip net.IP) string {
+	if v4 := ip.To4(); v4 != nil {
+		return v4.String()
+	}
+	return ip.Mask(net.CIDRMask(64, 128)).String() + "/64"
+}
+
+func ipFromAddr(addr net.Addr) net.IP {
+	switch v := addr.(type) {
+	case *net.IPNet:
+		return v.IP
+	case *net.IPAddr:
+		return v.IP
+	default:
+		return nil
+	}
+}

--- a/daemon/internal/api/service.go
+++ b/daemon/internal/api/service.go
@@ -63,6 +63,14 @@ type snowflakeManager interface {
 	Status() state.TransportStatus
 }
 
+// transportMemory records and recalls the transport that last established a
+// tunnel on a given network, so auto-connect can try it first. Satisfied by
+// *state.TransportMemoryStore; a nil field disables the optimization.
+type transportMemory interface {
+	Lookup(networkKey string) (string, bool)
+	Record(networkKey, transport string) error
+}
+
 type Service struct {
 	machine    *state.Machine
 	logs       *state.LogStore
@@ -74,6 +82,12 @@ type Service struct {
 	snowflake  snowflakeManager
 	wg         wg.Manager
 	killSwitch platform.KillSwitch
+
+	// transportMemory remembers the last-good transport per network; nil
+	// disables the reorder/record optimization. networkKey fingerprints the
+	// current network. Both are set once and read-only thereafter.
+	transportMemory transportMemory
+	networkKey      func() string
 
 	opMu sync.Mutex
 
@@ -92,6 +106,11 @@ type Service struct {
 	// when disconnected.
 	activeMu            sync.RWMutex
 	activeTransportKind string
+
+	// handshakeTimeout bounds how long a single transport is given to carry a
+	// first WireGuard handshake during bring-up. Defaults to
+	// defaultWireGuardHandshakeTimeout; tests set it small.
+	handshakeTimeout time.Duration
 }
 
 type wgPreflightChecker interface {
@@ -122,17 +141,26 @@ func NewService(
 	killSwitch platform.KillSwitch,
 ) *Service {
 	return &Service{
-		machine:    machine,
-		logs:       logs,
-		config:     config,
-		cloak:      cloakManager,
-		naive:      naiveManager,
-		reality:    realityManager,
-		hysteria2:  hysteria2Manager,
-		snowflake:  snowflakeManager,
-		wg:         wgManager,
-		killSwitch: killSwitch,
+		machine:          machine,
+		logs:             logs,
+		config:           config,
+		cloak:            cloakManager,
+		naive:            naiveManager,
+		reality:          realityManager,
+		hysteria2:        hysteria2Manager,
+		snowflake:        snowflakeManager,
+		wg:               wgManager,
+		killSwitch:       killSwitch,
+		handshakeTimeout: defaultWireGuardHandshakeTimeout,
+		networkKey:       currentNetworkKey,
 	}
+}
+
+// SetTransportMemory wires in the per-network last-good-transport cache. Called
+// once at startup; a nil store (or never calling this) leaves the optimization
+// off, in which case connects always walk the full cascade.
+func (s *Service) SetTransportMemory(store transportMemory) {
+	s.transportMemory = store
 }
 
 // activeTransport returns whichever manager is live for the current session,
@@ -140,8 +168,15 @@ func NewService(
 // use this instead of branching on transport kind.
 func (s *Service) activeTransport() transport.Manager {
 	s.activeMu.RLock()
-	defer s.activeMu.RUnlock()
-	switch s.activeTransportKind {
+	kind := s.activeTransportKind
+	s.activeMu.RUnlock()
+	return s.managerForKind(kind)
+}
+
+// managerForKind maps a transport kind to its manager, or nil for an unknown
+// or empty kind. Managers are fixed at construction, so this needs no lock.
+func (s *Service) managerForKind(kind string) transport.Manager {
+	switch kind {
 	case "cloak":
 		return s.cloak
 	case "naive":
@@ -286,51 +321,22 @@ func (s *Service) Connect(ctx context.Context, profileID string, opts ConnectOpt
 
 // bringUpAfterKillSwitch starts the transport + WireGuard and updates the
 // kill switch. Assumes opMu held, kill switch already Enable()d. Shared by
-// Connect and Switch.
+// Connect and Switch. StateConnected is reached only after a real WireGuard
+// handshake (proven per transport inside startTransportWithHandshake), so a
+// started-but-dead tunnel never reports connected.
 func (s *Service) bringUpAfterKillSwitch(ctx context.Context, profile state.Profile, wireGuardProfile state.WireGuardProfile, preferredTransport string) error {
 	s.machine.Set(state.StateConnecting, "starting transport")
 	stepStart := time.Now()
 
-	kind, err := s.startTransport(ctx, &profile, &wireGuardProfile, preferredTransport)
+	networkKey := s.currentNetworkKey()
+	kind, err := s.startTransportWithHandshake(ctx, &profile, &wireGuardProfile, preferredTransport, networkKey)
 	if err != nil {
 		s.setError(fmt.Sprintf("transport start failed: %v", err))
 		return err
 	}
 	s.setActiveTransportKind(kind)
-	s.logs.Add(state.LogInfo, state.SourceDaemon, fmt.Sprintf("%s transport started (%dms)", kind, time.Since(stepStart).Milliseconds()))
-
-	s.machine.Set(state.StateConnecting, "starting wireguard")
-	stepStart = time.Now()
-	s.logs.Add(state.LogInfo, state.SourceDaemon, fmt.Sprintf("starting wireguard tunnel=%s", wireGuardProfile.TunnelName))
-	if err := s.wg.Start(ctx, wireGuardProfile); err != nil {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cleanupCancel()
-		_ = s.activeTransport().Stop(cleanupCtx)
-		s.setActiveTransportKind("")
-		s.setError(fmt.Sprintf("wireguard start failed: %v", err))
-		return err
-	}
-
-	wgStatus, err := s.wg.Status(ctx, wireGuardProfile)
-	if err != nil {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cleanupCancel()
-		_ = s.wg.Stop(cleanupCtx, wireGuardProfile)
-		_ = s.activeTransport().Stop(cleanupCtx)
-		s.setActiveTransportKind("")
-		s.setError(fmt.Sprintf("wireguard status failed: %v", err))
-		return err
-	}
-	if !wgStatus.Running {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cleanupCancel()
-		_ = s.wg.Stop(cleanupCtx, wireGuardProfile)
-		_ = s.activeTransport().Stop(cleanupCtx)
-		s.setActiveTransportKind("")
-		s.setError(fmt.Sprintf("wireguard failed to reach running state: %s", wgStatus.Detail))
-		return errors.New("wireguard not running")
-	}
-	s.logs.Add(state.LogInfo, state.SourceDaemon, fmt.Sprintf("wireguard started (%dms)", time.Since(stepStart).Milliseconds()))
+	s.rememberTransport(networkKey, kind)
+	s.logs.Add(state.LogInfo, state.SourceDaemon, fmt.Sprintf("%s tunnel established with wireguard handshake (%dms)", kind, time.Since(stepStart).Milliseconds()))
 
 	stepStart = time.Now()
 	tunnelInterface := s.resolveWireGuardInterfaceName(ctx, wireGuardProfile)
@@ -578,139 +584,6 @@ func (s *Service) startSnowflakeTransport(ctx context.Context, profile *state.Pr
 	return nil
 }
 
-// startTransport: "cloak"/"naive"/"reality"/"hysteria2"/"snowflake" = that
-// transport only, no fallback (errors if the profile has no config for it).
-// "" (default) = cloak first, then naive, then reality, then hysteria2, then
-// snowflake.
-func (s *Service) startTransport(ctx context.Context, profile *state.Profile, wireGuardProfile *state.WireGuardProfile, preferredTransport string) (string, error) {
-	switch preferredTransport {
-	case "naive":
-		if profile.Naive == nil {
-			return "", errors.New("naive transport requested but this profile has no naive configuration")
-		}
-		if err := s.startNaiveTransport(ctx, profile, wireGuardProfile); err != nil {
-			return "", fmt.Errorf("naive: %w", err)
-		}
-		return "naive", nil
-	case "reality":
-		if profile.Reality == nil {
-			return "", errors.New("reality transport requested but this profile has no reality configuration")
-		}
-		if err := s.startRealityTransport(ctx, profile, wireGuardProfile); err != nil {
-			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 2*time.Second)
-			_ = s.reality.Stop(cleanupCtx)
-			cleanupCancel()
-			return "", fmt.Errorf("reality: %w", err)
-		}
-		return "reality", nil
-	case "hysteria2":
-		if profile.Hysteria2 == nil {
-			return "", errors.New("hysteria2 transport requested but this profile has no hysteria2 configuration")
-		}
-		if err := s.startHysteria2Transport(ctx, profile, wireGuardProfile); err != nil {
-			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 2*time.Second)
-			_ = s.hysteria2.Stop(cleanupCtx)
-			cleanupCancel()
-			return "", fmt.Errorf("hysteria2: %w", err)
-		}
-		return "hysteria2", nil
-	case "snowflake":
-		// Gated off for this release (see snowflakeReleaseGated). Re-enable by
-		// removing this guard.
-		if snowflakeReleaseGated {
-			return "", errors.New("snowflake transport is temporarily unavailable")
-		}
-		if profile.Snowflake == nil {
-			return "", errors.New("snowflake transport requested but this profile has no snowflake configuration")
-		}
-		if err := s.startSnowflakeTransport(ctx, profile, wireGuardProfile); err != nil {
-			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 2*time.Second)
-			_ = s.snowflake.Stop(cleanupCtx)
-			cleanupCancel()
-			return "", fmt.Errorf("snowflake: %w", err)
-		}
-		return "snowflake", nil
-	case "cloak":
-		if err := s.startCloakTransport(ctx, profile, wireGuardProfile); err != nil {
-			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 2*time.Second)
-			_ = s.cloak.Stop(cleanupCtx)
-			cleanupCancel()
-			return "", fmt.Errorf("cloak: %w", err)
-		}
-		return "cloak", nil
-	default:
-		if err := s.startCloakTransport(ctx, profile, wireGuardProfile); err != nil {
-			return s.fallbackToNaive(ctx, profile, wireGuardProfile, err)
-		}
-		return "cloak", nil
-	}
-}
-
-// fallbackToNaive is called once Cloak has failed at some stage of startup
-// during automatic ("" / "auto") mode. It stops whatever Cloak left
-// behind, and — only if the profile has a NaiveProxy fallback configured —
-// starts NaiveProxy in its place. Falls through to fallbackToReality if
-// naive isn't configured or also fails.
-func (s *Service) fallbackToNaive(ctx context.Context, profile *state.Profile, wireGuardProfile *state.WireGuardProfile, cloakErr error) (string, error) {
-	s.logs.Add(state.LogWarn, state.SourceDaemon, fmt.Sprintf("cloak transport failed, checking naive fallback: %v", cloakErr))
-	cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 2*time.Second)
-	_ = s.cloak.Stop(cleanupCtx)
-	cleanupCancel()
-
-	if profile.Naive == nil {
-		return s.fallbackToReality(ctx, profile, wireGuardProfile, cloakErr)
-	}
-
-	if err := s.startNaiveTransport(ctx, profile, wireGuardProfile); err != nil {
-		return s.fallbackToReality(ctx, profile, wireGuardProfile, fmt.Errorf("cloak: %v; naive: %w", cloakErr, err))
-	}
-
-	s.logs.Add(state.LogInfo, state.SourceDaemon, "fell back to naive transport after cloak failure")
-	return "naive", nil
-}
-
-// fallbackToReality is tried after cloak (and naive, if configured) have
-// failed in automatic mode. If reality isn't configured or also fails, it
-// falls through to fallbackToHysteria2. prevErr carries the accumulated
-// failure detail from earlier transports.
-func (s *Service) fallbackToReality(ctx context.Context, profile *state.Profile, wireGuardProfile *state.WireGuardProfile, prevErr error) (string, error) {
-	if profile.Reality == nil {
-		return s.fallbackToHysteria2(ctx, profile, wireGuardProfile, prevErr)
-	}
-
-	s.logs.Add(state.LogWarn, state.SourceDaemon, fmt.Sprintf("checking reality fallback: %v", prevErr))
-	if err := s.startRealityTransport(ctx, profile, wireGuardProfile); err != nil {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 2*time.Second)
-		_ = s.reality.Stop(cleanupCtx)
-		cleanupCancel()
-		return s.fallbackToHysteria2(ctx, profile, wireGuardProfile, fmt.Errorf("%v; reality: %w", prevErr, err))
-	}
-
-	s.logs.Add(state.LogInfo, state.SourceDaemon, "fell back to reality transport")
-	return "reality", nil
-}
-
-// fallbackToHysteria2 is tried after cloak, naive, and reality have failed
-// in automatic mode. If hysteria2 isn't configured or also fails, it falls
-// through to fallbackToSnowflake. prevErr carries the accumulated failure
-// detail from earlier transports.
-func (s *Service) fallbackToHysteria2(ctx context.Context, profile *state.Profile, wireGuardProfile *state.WireGuardProfile, prevErr error) (string, error) {
-	if profile.Hysteria2 == nil {
-		return s.fallbackToSnowflake(ctx, profile, wireGuardProfile, prevErr)
-	}
-
-	s.logs.Add(state.LogWarn, state.SourceDaemon, fmt.Sprintf("checking hysteria2 fallback: %v", prevErr))
-	if err := s.startHysteria2Transport(ctx, profile, wireGuardProfile); err != nil {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 2*time.Second)
-		_ = s.hysteria2.Stop(cleanupCtx)
-		cleanupCancel()
-		return s.fallbackToSnowflake(ctx, profile, wireGuardProfile, fmt.Errorf("%v; hysteria2: %w", prevErr, err))
-	}
-
-	s.logs.Add(state.LogInfo, state.SourceDaemon, "fell back to hysteria2 transport")
-	return "hysteria2", nil
-}
-
 // snowflakeReleaseGated disables the Snowflake transport for this release. Its
 // WebRTC data plane is dropped by the always-on kill switch: the negotiated
 // volunteer-proxy peer IP is discovered dynamically and is never permitted, so
@@ -719,31 +592,299 @@ func (s *Service) fallbackToHysteria2(ctx context.Context, profile *state.Profil
 // once the kill switch can permit the dynamic peer.
 const snowflakeReleaseGated = true
 
-// fallbackToSnowflake is the last-resort step in automatic mode, tried after
-// cloak, naive, reality, and hysteria2 have failed. prevErr carries the
-// accumulated failure detail from earlier transports.
-func (s *Service) fallbackToSnowflake(ctx context.Context, profile *state.Profile, wireGuardProfile *state.WireGuardProfile, prevErr error) (string, error) {
-	// Gated off for this release (see snowflakeReleaseGated): AUTO mode must
-	// never attempt snowflake. Return the same failure as the no-config path.
-	// Re-enable by removing this guard.
-	if snowflakeReleaseGated {
-		return "", fmt.Errorf("all configured transports failed: %w", prevErr)
+// transportStartFn starts one transport's process/session and rebinds the
+// WireGuard endpoint to its loopback port. It is the transport-level half of a
+// bring-up; the WireGuard handshake in bringUpTransport is the tunnel-level
+// half. Matches the signature of startCloakTransport and friends.
+type transportStartFn func(ctx context.Context, profile *state.Profile, wireGuardProfile *state.WireGuardProfile) error
+
+type transportCandidate struct {
+	kind  string
+	start transportStartFn
+}
+
+// transportCandidates returns the ordered transports to attempt for the given
+// selection. "" / "auto" = the censorship-resistance cascade (see autoCascade).
+// A specific selection = just that transport, with an error if the profile has
+// no configuration for it.
+func (s *Service) transportCandidates(profile *state.Profile, preferredTransport string) ([]transportCandidate, error) {
+	switch preferredTransport {
+	case "", "auto":
+		return s.autoCascade(profile), nil
+	case "cloak":
+		return []transportCandidate{{"cloak", s.startCloakTransport}}, nil
+	case "naive":
+		if profile.Naive == nil {
+			return nil, errors.New("naive transport requested but this profile has no naive configuration")
+		}
+		return []transportCandidate{{"naive", s.startNaiveTransport}}, nil
+	case "reality":
+		if profile.Reality == nil {
+			return nil, errors.New("reality transport requested but this profile has no reality configuration")
+		}
+		return []transportCandidate{{"reality", s.startRealityTransport}}, nil
+	case "hysteria2":
+		if profile.Hysteria2 == nil {
+			return nil, errors.New("hysteria2 transport requested but this profile has no hysteria2 configuration")
+		}
+		return []transportCandidate{{"hysteria2", s.startHysteria2Transport}}, nil
+	case "snowflake":
+		// Gated off for this release (see snowflakeReleaseGated). Re-enable by
+		// removing this guard.
+		if snowflakeReleaseGated {
+			return nil, errors.New("snowflake transport is temporarily unavailable")
+		}
+		if profile.Snowflake == nil {
+			return nil, errors.New("snowflake transport requested but this profile has no snowflake configuration")
+		}
+		return []transportCandidate{{"snowflake", s.startSnowflakeTransport}}, nil
+	default:
+		return nil, fmt.Errorf("unknown transport %q", preferredTransport)
+	}
+}
+
+// autoCascadeOrder is the auto-mode fallback order, chosen for censorship
+// resistance rather than build history — because the transports hide in
+// different ways, a block that stops one often stops others that hide the same
+// way, so consecutive attempts favor a different mechanism:
+//
+//   - cloak: the reliable default (TLS obfuscation to a decoy cover site).
+//   - reality: the strongest TLS disguise — borrows a real site's TLS
+//     handshake, so active probing and SNI blocking see a genuine site.
+//   - hysteria2: a different wire protocol (UDP/QUIC + Salamander), so a block
+//     that kills the TCP/TLS transports does not kill every attempt.
+//   - naive: real Chromium TLS+HTTP/2 — a different TLS fingerprint than
+//     reality, for when UDP is blocked and reality's approach was the problem.
+//   - snowflake: heavy-artillery last resort (WebRTC rendezvous, no fixed
+//     endpoint); currently gated off (see snowflakeReleaseGated).
+//
+// Per-network memory can still promote whatever last worked here ahead of this
+// default (see reorderByMemory).
+var autoCascadeOrder = []string{"cloak", "reality", "hysteria2", "naive", "snowflake"}
+
+// autoCascade builds the auto-mode candidate list in autoCascadeOrder, keeping
+// only the transports this profile actually configures.
+func (s *Service) autoCascade(profile *state.Profile) []transportCandidate {
+	candidates := make([]transportCandidate, 0, len(autoCascadeOrder))
+	for _, kind := range autoCascadeOrder {
+		if start, ok := s.transportStarter(profile, kind); ok {
+			candidates = append(candidates, transportCandidate{kind, start})
+		}
+	}
+	return candidates
+}
+
+// transportStarter returns the start func for kind if the profile can attempt
+// it: Cloak is always available; the others require their optional profile
+// block, and Snowflake is additionally gated off for this release.
+func (s *Service) transportStarter(profile *state.Profile, kind string) (transportStartFn, bool) {
+	switch kind {
+	case "cloak":
+		return s.startCloakTransport, true
+	case "reality":
+		if profile.Reality == nil {
+			return nil, false
+		}
+		return s.startRealityTransport, true
+	case "hysteria2":
+		if profile.Hysteria2 == nil {
+			return nil, false
+		}
+		return s.startHysteria2Transport, true
+	case "naive":
+		if profile.Naive == nil {
+			return nil, false
+		}
+		return s.startNaiveTransport, true
+	case "snowflake":
+		if snowflakeReleaseGated || profile.Snowflake == nil {
+			return nil, false
+		}
+		return s.startSnowflakeTransport, true
+	default:
+		return nil, false
+	}
+}
+
+// startTransportWithHandshake brings up the first candidate transport that
+// carries a real WireGuard handshake, and returns its kind. Because a mere
+// started transport process is no longer accepted as "connected" (a dead or
+// blocked server can start the process and never carry traffic), each
+// candidate is proven end-to-end by bringUpTransport; a candidate that starts
+// but never handshakes is torn down and the next is tried. In auto mode this
+// is the fallback chain; with a specific transport there is a single candidate
+// and no fallback.
+func (s *Service) startTransportWithHandshake(ctx context.Context, profile *state.Profile, wireGuardProfile *state.WireGuardProfile, preferredTransport, networkKey string) (string, error) {
+	candidates, err := s.transportCandidates(profile, preferredTransport)
+	if err != nil {
+		return "", err
+	}
+	candidates = s.reorderByMemory(candidates, preferredTransport, networkKey)
+
+	var failures []string
+	for i, candidate := range candidates {
+		if err := s.bringUpTransport(ctx, profile, wireGuardProfile, candidate.kind, candidate.start); err != nil {
+			// A cancelled context means Disconnect interrupted us; stop trying.
+			if ctx.Err() != nil {
+				return "", ctx.Err()
+			}
+			failures = append(failures, err.Error())
+			s.logs.Add(state.LogWarn, state.SourceDaemon, fmt.Sprintf("%s transport did not establish a tunnel: %v", candidate.kind, err))
+			continue
+		}
+		if i > 0 {
+			s.logs.Add(state.LogInfo, state.SourceDaemon, fmt.Sprintf("fell back to %s transport", candidate.kind))
+		}
+		return candidate.kind, nil
 	}
 
-	if profile.Snowflake == nil {
-		return "", fmt.Errorf("all configured transports failed: %w", prevErr)
+	if len(failures) == 1 {
+		return "", errors.New(failures[0])
+	}
+	return "", fmt.Errorf("all configured transports failed: %s", strings.Join(failures, "; "))
+}
+
+// currentNetworkKey returns the fingerprint of the network the host is on, or
+// "" when it can't be determined. Nil-safe wrapper around the injectable
+// networkKey func.
+func (s *Service) currentNetworkKey() string {
+	if s.networkKey == nil {
+		return ""
+	}
+	return s.networkKey()
+}
+
+// reorderByMemory moves the transport last known to work on this network to the
+// front of the auto-mode candidate list, so a repeat connect on a familiar
+// network tries the winner first instead of walking the whole cascade. Only
+// applies in auto mode; a specific-transport request is left untouched.
+func (s *Service) reorderByMemory(candidates []transportCandidate, preferredTransport, networkKey string) []transportCandidate {
+	if s.transportMemory == nil || len(candidates) < 2 {
+		return candidates
+	}
+	if preferredTransport != "" && preferredTransport != "auto" {
+		return candidates
+	}
+	remembered, ok := s.transportMemory.Lookup(networkKey)
+	if !ok {
+		return candidates
+	}
+	idx := -1
+	for i, candidate := range candidates {
+		if candidate.kind == remembered {
+			idx = i
+			break
+		}
+	}
+	if idx <= 0 {
+		// Not configured for this profile, or already first — nothing to do.
+		return candidates
+	}
+	reordered := make([]transportCandidate, 0, len(candidates))
+	reordered = append(reordered, candidates[idx])
+	reordered = append(reordered, candidates[:idx]...)
+	reordered = append(reordered, candidates[idx+1:]...)
+	s.logs.Add(state.LogInfo, state.SourceDaemon, fmt.Sprintf("trying %s first (last worked on this network)", remembered))
+	return reordered
+}
+
+// rememberTransport records kind as the last-good transport for networkKey so
+// the next auto-connect on this network tries it first. Best-effort: a nil
+// store, empty key, or persist error only forfeits the optimization.
+func (s *Service) rememberTransport(networkKey, kind string) {
+	if s.transportMemory == nil || networkKey == "" || kind == "" {
+		return
+	}
+	if err := s.transportMemory.Record(networkKey, kind); err != nil {
+		s.logs.Add(state.LogWarn, state.SourceDaemon, fmt.Sprintf("failed to record last-good transport for network: %v", err))
+	}
+}
+
+// bringUpTransport starts one transport, brings WireGuard up over it, and waits
+// for a real WireGuard handshake — the proof the tunnel reaches the server
+// through this transport. On any failure it tears WireGuard and the transport
+// back down so the caller can try the next candidate. Making the handshake
+// (not a merely started process) the success criterion is what lets a dead
+// server fall through to the next transport, and what lets Cloak — which
+// cannot prove its own session at start time — be validated here instead.
+func (s *Service) bringUpTransport(ctx context.Context, profile *state.Profile, wireGuardProfile *state.WireGuardProfile, kind string, start transportStartFn) (err error) {
+	defer func() {
+		if err != nil {
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 2*time.Second)
+			_ = s.wg.Stop(cleanupCtx, *wireGuardProfile)
+			if mgr := s.managerForKind(kind); mgr != nil {
+				_ = mgr.Stop(cleanupCtx)
+			}
+			cleanupCancel()
+		}
+	}()
+
+	if err = start(ctx, profile, wireGuardProfile); err != nil {
+		return fmt.Errorf("%s: %w", kind, err)
 	}
 
-	s.logs.Add(state.LogWarn, state.SourceDaemon, fmt.Sprintf("checking snowflake fallback: %v", prevErr))
-	if err := s.startSnowflakeTransport(ctx, profile, wireGuardProfile); err != nil {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 2*time.Second)
-		_ = s.snowflake.Stop(cleanupCtx)
-		cleanupCancel()
-		return "", fmt.Errorf("all transports failed: %v; snowflake: %w", prevErr, err)
+	s.machine.Set(state.StateConnecting, fmt.Sprintf("starting wireguard over %s", kind))
+	if err = s.wg.Start(ctx, *wireGuardProfile); err != nil {
+		return fmt.Errorf("%s: wireguard start: %w", kind, err)
 	}
 
-	s.logs.Add(state.LogInfo, state.SourceDaemon, "fell back to snowflake transport")
-	return "snowflake", nil
+	var wgStatus state.WireGuardStatus
+	if wgStatus, err = s.wg.Status(ctx, *wireGuardProfile); err != nil {
+		return fmt.Errorf("%s: wireguard status: %w", kind, err)
+	}
+	if !wgStatus.Running {
+		err = fmt.Errorf("%s: wireguard failed to reach running state: %s", kind, wgStatus.Detail)
+		return err
+	}
+
+	s.machine.Set(state.StateConnecting, fmt.Sprintf("waiting for %s handshake", kind))
+	if err = s.waitForWireGuardHandshake(ctx, *wireGuardProfile); err != nil {
+		return fmt.Errorf("%s: %w", kind, err)
+	}
+	return nil
+}
+
+// defaultWireGuardHandshakeTimeout bounds how long a single transport is given
+// to carry a first WireGuard handshake before it is abandoned for the next
+// candidate. Matches the per-transport session timeouts (Cloak dials its server
+// on the first WireGuard packet, so the handshake also covers Cloak's session).
+const defaultWireGuardHandshakeTimeout = 10 * time.Second
+
+// wireGuardHandshakePollInterval is how often waitForWireGuardHandshake
+// re-reads WireGuard status while waiting for the first handshake.
+const wireGuardHandshakePollInterval = 200 * time.Millisecond
+
+// waitForWireGuardHandshake blocks until WireGuard completes a peer handshake
+// (LastHandshakeUnix becomes non-zero) or the timeout elapses. A freshly
+// started device has no prior handshake, so any non-zero value belongs to this
+// session. Returns an error if the interface drops, the deadline passes, or ctx
+// is cancelled (Disconnect).
+func (s *Service) waitForWireGuardHandshake(ctx context.Context, wireGuardProfile state.WireGuardProfile) error {
+	timeout := s.handshakeTimeout
+	if timeout <= 0 {
+		timeout = defaultWireGuardHandshakeTimeout
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		status, err := s.wg.Status(ctx, wireGuardProfile)
+		if err != nil {
+			return fmt.Errorf("wireguard status during handshake wait: %w", err)
+		}
+		if !status.Running {
+			return errors.New("wireguard interface went down before handshake")
+		}
+		if status.LastHandshakeUnix > 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("no wireguard handshake within %s", timeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(wireGuardHandshakePollInterval):
+		}
+	}
 }
 
 // Switch hot-swaps profile without dropping the kill switch. Interruptible
@@ -1112,11 +1253,34 @@ func (s *Service) runHealthCheck(ctx context.Context) {
 		s.setError(fmt.Sprintf("health check failed: wireguard tunnel is down (%s)", wgStatus.Detail))
 		return
 	}
+	if s.wireGuardHandshakeStale(wgStatus) {
+		age := time.Since(time.Unix(wgStatus.LastHandshakeUnix, 0)).Round(time.Second)
+		s.setError(fmt.Sprintf("health check failed: wireguard tunnel is silent (no handshake for %s)", age))
+		return
+	}
 
 	if !s.killSwitch.Active() {
 		s.setError("health check failed: kill switch was cleared unexpectedly")
 		return
 	}
+}
+
+// wireGuardHandshakeStaleAfter is how long a Connected tunnel may go without a
+// completed handshake before it is treated as dead. WireGuard rekeys well
+// inside this on a live link — REKEY_AFTER_TIME is 120s and a session is
+// unusable after REJECT_AFTER_TIME (180s), so with keepalive traffic a fresh
+// handshake always lands sooner. An older one means the peer is unreachable.
+const wireGuardHandshakeStaleAfter = 180 * time.Second
+
+// wireGuardHandshakeStale reports whether a Connected tunnel has gone silent:
+// it handshaked at least once (so this isn't a still-connecting tunnel — that
+// case is gated at connect time) but the newest handshake is older than
+// wireGuardHandshakeStaleAfter.
+func (s *Service) wireGuardHandshakeStale(status state.WireGuardStatus) bool {
+	if status.LastHandshakeUnix <= 0 {
+		return false
+	}
+	return time.Since(time.Unix(status.LastHandshakeUnix, 0)) > wireGuardHandshakeStaleAfter
 }
 
 // recoverActiveTransport restarts whichever transport is active in-place —

--- a/daemon/internal/api/service_test.go
+++ b/daemon/internal/api/service_test.go
@@ -320,6 +320,16 @@ type fakeWGManager struct {
 	startCount     int
 	stopCount      int
 	preflightCount int
+
+	// Handshake modeling for the connection-readiness gate. Default (all zero,
+	// noHandshake false) = a live tunnel that handshakes as soon as it is
+	// running. noHandshake = a dead tunnel that never handshakes. handshakeOnStart
+	// = only handshake once startCount reaches it (to model a transport whose
+	// server is dead so an earlier candidate fails and a later one succeeds).
+	// handshakeUnix overrides the reported handshake time (e.g. a stale one).
+	noHandshake      bool
+	handshakeOnStart int
+	handshakeUnix    int64
 }
 
 func (f *fakeWGManager) Start(_ context.Context, _ state.WireGuardProfile) error {
@@ -350,7 +360,22 @@ func (f *fakeWGManager) Status(_ context.Context, _ state.WireGuardProfile) (sta
 	if f.statusErr != nil {
 		return state.WireGuardStatus{}, f.statusErr
 	}
-	return state.WireGuardStatus{Running: f.running, Detail: "fake"}, nil
+	return state.WireGuardStatus{Running: f.running, Detail: "fake", LastHandshakeUnix: f.lastHandshakeLocked()}, nil
+}
+
+// lastHandshakeLocked returns the handshake time the fake should report; caller
+// holds f.mu.
+func (f *fakeWGManager) lastHandshakeLocked() int64 {
+	if f.handshakeUnix != 0 {
+		return f.handshakeUnix
+	}
+	if !f.running || f.noHandshake {
+		return 0
+	}
+	if f.handshakeOnStart > 0 && f.startCount < f.handshakeOnStart {
+		return 0
+	}
+	return time.Now().Unix()
 }
 
 func (f *fakeWGManager) Preflight(_ context.Context, _ state.WireGuardProfile) error {
@@ -371,6 +396,29 @@ func (f *fakeWGManager) ActiveInterfaceName(_ context.Context, _ state.WireGuard
 
 func (f *fakeWGManager) ActiveLUIDs() map[uint64]struct{} {
 	return map[uint64]struct{}{}
+}
+
+// fakeTransportMemory is an in-memory transportMemory for tests.
+type fakeTransportMemory struct {
+	mu      sync.Mutex
+	entries map[string]string
+}
+
+func (f *fakeTransportMemory) Lookup(networkKey string) (string, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	transport, ok := f.entries[networkKey]
+	return transport, ok && transport != ""
+}
+
+func (f *fakeTransportMemory) Record(networkKey, transport string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.entries == nil {
+		f.entries = map[string]string{}
+	}
+	f.entries[networkKey] = transport
+	return nil
 }
 
 type fakeKillSwitch struct {
@@ -510,7 +558,11 @@ func newTestServiceFull(
 	machine := state.NewMachine()
 	logs := state.NewLogStore(100)
 	config := testConfigStore(t, profiles...)
-	return NewService(machine, logs, config, cloak, naive, reality, hysteria2, snowflake, wgMgr, ks)
+	svc := NewService(machine, logs, config, cloak, naive, reality, hysteria2, snowflake, wgMgr, ks)
+	// Keep handshake-gated failure paths fast in tests; a live fake tunnel
+	// handshakes on the first status poll, so success paths are unaffected.
+	svc.handshakeTimeout = 200 * time.Millisecond
+	return svc
 }
 
 // ---------------------------------------------------------------------------
@@ -1089,6 +1141,242 @@ func TestConnect_PreferredTransportNaive_ErrorsWhenProfileHasNoNaiveConfig(t *te
 	}
 }
 
+// TestConnect_NoWireGuardHandshake_DoesNotConnect proves the readiness gate:
+// a transport whose process starts but whose tunnel never handshakes does not
+// count as connected, and WireGuard is torn back down.
+func TestConnect_NoWireGuardHandshake_DoesNotConnect(t *testing.T) {
+	profile := testProfile()
+	cloak := &fakeCloakManager{}
+	wgMgr := &fakeWGManager{noHandshake: true}
+	ks := &fakeKillSwitch{}
+	svc := newTestService(t, cloak, &fakeNaiveManager{}, wgMgr, ks, profile)
+
+	err := svc.Connect(context.Background(), profile.ID, ConnectOptions{PreferredTransport: "cloak"})
+	if err == nil {
+		t.Fatal("expected connect to fail when WireGuard never handshakes")
+	}
+	if st := svc.Status(context.Background()).State; st == state.StateConnected {
+		t.Fatalf("state = %q, want not CONNECTED", st)
+	}
+	wgMgr.mu.Lock()
+	running := wgMgr.running
+	wgMgr.mu.Unlock()
+	if running {
+		t.Error("expected WireGuard to be stopped after handshake failure")
+	}
+}
+
+// TestConnect_FallsBackWhenTransportStartsButHandshakeNeverCompletes proves the
+// handshake is the fallback trigger: cloak starts cleanly but no handshake ever
+// lands through it, so the daemon advances to naive, which does handshake.
+func TestConnect_FallsBackWhenTransportStartsButHandshakeNeverCompletes(t *testing.T) {
+	profile := state.Profile{
+		ID:    "p1",
+		Name:  "p1",
+		Cloak: state.CloakProfile{RemoteHost: "example.com", RemotePort: 443, LocalPort: 51821},
+		Naive: &state.NaiveProfile{RemoteHost: "example.com", RemotePort: 443, Username: "u", Password: "p"},
+		WireGuard: state.WireGuardProfile{
+			TunnelName: "pangea0",
+			ConfigText: "[Interface]\nPrivateKey=x\n[Peer]\nEndpoint=127.0.0.1:51821\nPublicKey=y\nAllowedIPs=0.0.0.0/0\n",
+		},
+	}
+	cloak := &fakeCloakManager{}
+	naive := &fakeNaiveManager{}
+	// Handshake only completes once the second transport (naive) brings WG up.
+	wgMgr := &fakeWGManager{handshakeOnStart: 2}
+	ks := &fakeKillSwitch{}
+	svc := newTestService(t, cloak, naive, wgMgr, ks, profile)
+
+	if err := svc.Connect(context.Background(), "p1", ConnectOptions{}); err != nil {
+		t.Fatalf("connect failed: %v", err)
+	}
+	status := svc.Status(context.Background())
+	if status.State != state.StateConnected {
+		t.Fatalf("state = %q, want CONNECTED", status.State)
+	}
+	if status.ActiveTransport != "naive" {
+		t.Fatalf("ActiveTransport = %q, want naive (cloak started but carried no handshake)", status.ActiveTransport)
+	}
+	if cloak.stopCount == 0 {
+		t.Error("expected cloak to be stopped after its tunnel failed to handshake")
+	}
+	if !naive.startCalled {
+		t.Error("expected naive to be attempted after cloak")
+	}
+}
+
+// TestConnect_ConnectedReportsWireGuardHandshake proves the successful path
+// surfaces the handshake time in status.
+func TestConnect_ConnectedReportsWireGuardHandshake(t *testing.T) {
+	profile := testProfile()
+	cloak := &fakeCloakManager{}
+	wgMgr := &fakeWGManager{}
+	ks := &fakeKillSwitch{}
+	svc := newTestService(t, cloak, &fakeNaiveManager{}, wgMgr, ks, profile)
+
+	if err := svc.Connect(context.Background(), profile.ID, ConnectOptions{}); err != nil {
+		t.Fatalf("connect failed: %v", err)
+	}
+	status := svc.Status(context.Background())
+	if status.State != state.StateConnected {
+		t.Fatalf("state = %q, want CONNECTED", status.State)
+	}
+	if status.WireGuard.LastHandshakeUnix <= 0 {
+		t.Fatal("expected a non-zero WireGuard handshake time once connected")
+	}
+}
+
+// TestHealthCheck_StaleWireGuardHandshakeMarksError proves the ongoing health
+// check flags a tunnel that goes silent mid-session (no handshake within the
+// stale window) even though the interface and transport still report running.
+func TestHealthCheck_StaleWireGuardHandshakeMarksError(t *testing.T) {
+	profile := state.Profile{
+		ID:    "p1",
+		Name:  "p1",
+		Cloak: state.CloakProfile{RemoteHost: "example.com", RemotePort: 443, LocalPort: 51821},
+		Naive: &state.NaiveProfile{RemoteHost: "example.com", RemotePort: 443, Username: "u", Password: "p"},
+		WireGuard: state.WireGuardProfile{
+			TunnelName: "pangea0",
+			ConfigText: "[Interface]\nPrivateKey=x\n[Peer]\nEndpoint=127.0.0.1:51821\nPublicKey=y\nAllowedIPs=0.0.0.0/0\n",
+		},
+	}
+	cloak := &fakeCloakManager{}
+	naive := &fakeNaiveManager{}
+	wgMgr := &fakeWGManager{}
+	ks := &fakeKillSwitch{}
+	svc := newTestService(t, cloak, naive, wgMgr, ks, profile)
+
+	if err := svc.Connect(context.Background(), "p1", ConnectOptions{PreferredTransport: "naive"}); err != nil {
+		t.Fatalf("connect failed: %v", err)
+	}
+
+	// Tunnel goes silent: the newest handshake is well past the stale window.
+	wgMgr.mu.Lock()
+	wgMgr.handshakeUnix = time.Now().Add(-(wireGuardHandshakeStaleAfter + time.Minute)).Unix()
+	wgMgr.mu.Unlock()
+
+	svc.runHealthCheck(context.Background())
+
+	if st := svc.Status(context.Background()).State; st != state.StateError {
+		t.Fatalf("state = %q, want ERROR after stale handshake", st)
+	}
+}
+
+// transportMemoryProfile builds a profile with cloak + naive + reality all
+// configured, for the per-network transport-memory tests.
+func transportMemoryProfile() state.Profile {
+	return state.Profile{
+		ID:      "p1",
+		Name:    "p1",
+		Cloak:   state.CloakProfile{RemoteHost: "example.com", RemotePort: 443, LocalPort: 51821},
+		Naive:   &state.NaiveProfile{RemoteHost: "example.com", RemotePort: 443, Username: "u", Password: "p"},
+		Reality: &state.RealityProfile{RemoteHost: "reality.example.com", RemotePort: 8443, UUID: "u", PublicKey: "k", ShortID: "ab12"},
+		WireGuard: state.WireGuardProfile{
+			TunnelName: "pangea0",
+			ConfigText: "[Interface]\nPrivateKey=x\n[Peer]\nEndpoint=127.0.0.1:51821\nPublicKey=y\nAllowedIPs=0.0.0.0/0\n",
+		},
+	}
+}
+
+// TestConnect_RecordsLastGoodTransportForNetwork proves the daemon remembers
+// which transport actually established a tunnel, keyed by network: cloak fails
+// to handshake, naive succeeds, so naive is recorded for this network.
+func TestConnect_RecordsLastGoodTransportForNetwork(t *testing.T) {
+	// cloak + naive only, so the second transport attempted is deterministically
+	// naive regardless of the wider cascade order.
+	profile := state.Profile{
+		ID:    "p1",
+		Name:  "p1",
+		Cloak: state.CloakProfile{RemoteHost: "example.com", RemotePort: 443, LocalPort: 51821},
+		Naive: &state.NaiveProfile{RemoteHost: "example.com", RemotePort: 443, Username: "u", Password: "p"},
+		WireGuard: state.WireGuardProfile{
+			TunnelName: "pangea0",
+			ConfigText: "[Interface]\nPrivateKey=x\n[Peer]\nEndpoint=127.0.0.1:51821\nPublicKey=y\nAllowedIPs=0.0.0.0/0\n",
+		},
+	}
+	cloak := &fakeCloakManager{}
+	naive := &fakeNaiveManager{}
+	// Handshake only completes on the second transport's WG bring-up (naive).
+	wgMgr := &fakeWGManager{handshakeOnStart: 2}
+	ks := &fakeKillSwitch{}
+	mem := &fakeTransportMemory{}
+	svc := newTestService(t, cloak, naive, wgMgr, ks, profile)
+	svc.transportMemory = mem
+	svc.networkKey = func() string { return "wifi-home" }
+
+	if err := svc.Connect(context.Background(), "p1", ConnectOptions{}); err != nil {
+		t.Fatalf("connect failed: %v", err)
+	}
+	if got := svc.Status(context.Background()).ActiveTransport; got != "naive" {
+		t.Fatalf("ActiveTransport = %q, want naive", got)
+	}
+	if got, _ := mem.Lookup("wifi-home"); got != "naive" {
+		t.Fatalf("remembered transport = %q, want naive", got)
+	}
+}
+
+// TestConnect_TriesRememberedTransportFirst proves the remembered transport is
+// attempted before the rest of the cascade: reality is remembered and works, so
+// cloak (normally first) is never even started.
+func TestConnect_TriesRememberedTransportFirst(t *testing.T) {
+	profile := transportMemoryProfile()
+	cloak := &fakeCloakManager{}
+	naive := &fakeNaiveManager{}
+	reality := &fakeRealityManager{}
+	wgMgr := &fakeWGManager{} // live tunnel: whichever transport is tried first handshakes
+	ks := &fakeKillSwitch{}
+	mem := &fakeTransportMemory{entries: map[string]string{"wifi-home": "reality"}}
+	svc := newTestServiceWithReality(t, cloak, naive, reality, wgMgr, ks, profile)
+	svc.transportMemory = mem
+	svc.networkKey = func() string { return "wifi-home" }
+
+	if err := svc.Connect(context.Background(), "p1", ConnectOptions{}); err != nil {
+		t.Fatalf("connect failed: %v", err)
+	}
+	if svc.Status(context.Background()).ActiveTransport != "reality" {
+		t.Fatalf("ActiveTransport = %q, want reality (remembered)", svc.Status(context.Background()).ActiveTransport)
+	}
+	if cloak.startCalled {
+		t.Error("cloak should not be started when the remembered transport works first")
+	}
+	if !reality.startCalled {
+		t.Error("reality (remembered) should have been tried first")
+	}
+}
+
+// TestConnect_RememberedTransportFailsNow_FallsBackAndRerecords proves a stale
+// memory doesn't strand the connection: reality is remembered but no longer
+// handshakes, so the daemon falls through the rest of the cascade and updates
+// the memory to the new winner.
+func TestConnect_RememberedTransportFailsNow_FallsBackAndRerecords(t *testing.T) {
+	profile := transportMemoryProfile()
+	cloak := &fakeCloakManager{}
+	naive := &fakeNaiveManager{}
+	reality := &fakeRealityManager{}
+	// Reordered cascade is [reality, cloak, naive]; only the 2nd WG bring-up
+	// (cloak) handshakes, so reality fails and cloak becomes the new winner.
+	wgMgr := &fakeWGManager{handshakeOnStart: 2}
+	ks := &fakeKillSwitch{}
+	mem := &fakeTransportMemory{entries: map[string]string{"wifi-home": "reality"}}
+	svc := newTestServiceWithReality(t, cloak, naive, reality, wgMgr, ks, profile)
+	svc.transportMemory = mem
+	svc.networkKey = func() string { return "wifi-home" }
+
+	if err := svc.Connect(context.Background(), "p1", ConnectOptions{}); err != nil {
+		t.Fatalf("connect failed: %v", err)
+	}
+	active := svc.Status(context.Background()).ActiveTransport
+	if active == "reality" {
+		t.Fatal("expected to fall back off the stale remembered transport")
+	}
+	if active != "cloak" {
+		t.Fatalf("ActiveTransport = %q, want cloak (next in reordered cascade)", active)
+	}
+	if got, _ := mem.Lookup("wifi-home"); got != "cloak" {
+		t.Fatalf("remembered transport = %q, want cloak after re-record", got)
+	}
+}
+
 // naiveFallbackProfile builds a profile that falls back to naive (cloak
 // always fails to start) for the fallbackToNaive regression tests below.
 // Naive.LocalPort and the WireGuard config's loopback Endpoint line are
@@ -1307,12 +1595,14 @@ func TestConnect_PreferredTransportReality_ErrorsWhenProfileHasNoRealityConfig(t
 	}
 }
 
-func TestConnect_CloakAndNaiveFail_FallsBackToReality(t *testing.T) {
+func TestConnect_CloakFails_FallsBackToRealityBeforeNaive(t *testing.T) {
+	// In the censorship-resistance cascade REALITY precedes NaiveProxy, so a
+	// cloak failure falls through to reality and naive is never reached.
 	profile := realityProfile()
 	profile.Naive = &state.NaiveProfile{RemoteHost: "naive.example.com", RemotePort: 8443, Username: "u", Password: "p"}
 
 	cloakMgr := &fakeCloakManager{startErr: errors.New("cloak boom")}
-	naiveMgr := &fakeNaiveManager{startErr: errors.New("naive boom")}
+	naiveMgr := &fakeNaiveManager{}
 	realityMgr := &fakeRealityManager{}
 	wgMgr := &fakeWGManager{}
 	ks := &fakeKillSwitch{}
@@ -1324,19 +1614,63 @@ func TestConnect_CloakAndNaiveFail_FallsBackToReality(t *testing.T) {
 	if !cloakMgr.startCalled {
 		t.Fatal("expected cloak.Start to be attempted first")
 	}
-	if !naiveMgr.startCalled {
-		t.Fatal("expected naive.Start to be attempted after cloak failed")
-	}
-	realityMgr.mu.Lock()
-	startCalled := realityMgr.startCalled
-	realityMgr.mu.Unlock()
-	if !startCalled {
-		t.Fatal("expected reality.Start to be attempted after both cloak and naive failed")
-	}
-
 	status := svc.Status(context.Background())
 	if status.ActiveTransport != "reality" {
 		t.Fatalf("ActiveTransport = %q, want reality", status.ActiveTransport)
+	}
+	realityMgr.mu.Lock()
+	realityStarted := realityMgr.startCalled
+	realityMgr.mu.Unlock()
+	if !realityStarted {
+		t.Fatal("expected reality.Start to be attempted after cloak failed")
+	}
+	naiveMgr.mu.Lock()
+	naiveStarted := naiveMgr.startCalled
+	naiveMgr.mu.Unlock()
+	if naiveStarted {
+		t.Fatal("naive should not be reached — reality precedes it in the cascade")
+	}
+}
+
+// TestConnect_AutoCascadeAttemptsTransportsInCensorshipOrder pins the auto-mode
+// order: cloak, then reality, then hysteria2, then naive (snowflake is gated
+// off). With every transport configured but none able to handshake, the
+// aggregated failure records the order they were attempted in.
+func TestConnect_AutoCascadeAttemptsTransportsInCensorshipOrder(t *testing.T) {
+	profile := state.Profile{
+		ID:        "p1",
+		Name:      "p1",
+		Cloak:     state.CloakProfile{RemoteHost: "example.com", RemotePort: 443, LocalPort: 51821},
+		Naive:     &state.NaiveProfile{RemoteHost: "n.example.com", RemotePort: 443, Username: "u", Password: "p"},
+		Reality:   &state.RealityProfile{RemoteHost: "r.example.com", RemotePort: 8443, UUID: "u", PublicKey: "k", ShortID: "ab12"},
+		Hysteria2: &state.Hysteria2Profile{RemoteHost: "h.example.com", RemotePort: 8443, Password: "p", ObfsPassword: "o"},
+		WireGuard: state.WireGuardProfile{
+			TunnelName: "pangea0",
+			ConfigText: "[Interface]\nPrivateKey=x\n[Peer]\nEndpoint=127.0.0.1:51821\nPublicKey=y\nAllowedIPs=0.0.0.0/0\n",
+		},
+	}
+	wgMgr := &fakeWGManager{noHandshake: true} // every transport starts but no tunnel handshakes
+	ks := &fakeKillSwitch{}
+	svc := newTestServiceFull(t, &fakeCloakManager{}, &fakeNaiveManager{}, &fakeRealityManager{}, &fakeHysteria2Manager{}, &fakeSnowflakeManager{}, wgMgr, ks, profile)
+
+	err := svc.Connect(context.Background(), "p1", ConnectOptions{})
+	if err == nil {
+		t.Fatal("expected connect to fail when nothing handshakes")
+	}
+	msg := err.Error()
+	lastIdx := -1
+	for _, kind := range []string{"cloak", "reality", "hysteria2", "naive"} {
+		idx := strings.Index(msg, kind+":")
+		if idx < 0 {
+			t.Fatalf("error missing %s attempt: %v", kind, msg)
+		}
+		if idx < lastIdx {
+			t.Fatalf("%s attempted out of cascade order in: %v", kind, msg)
+		}
+		lastIdx = idx
+	}
+	if strings.Contains(msg, "snowflake:") {
+		t.Fatalf("snowflake is gated and must not be attempted in auto mode: %v", msg)
 	}
 }
 

--- a/daemon/internal/platform/paths_shared.go
+++ b/daemon/internal/platform/paths_shared.go
@@ -1,0 +1,14 @@
+package platform
+
+import "path/filepath"
+
+// TransportMemoryPath is where the daemon persists the per-network map of the
+// transport that last established a tunnel, so auto-connect can try it first on
+// a familiar network. Lives alongside config.json in the app support dir.
+func TransportMemoryPath() (string, error) {
+	appDir, err := AppSupportDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(appDir, "transport-memory.json"), nil
+}

--- a/daemon/internal/state/transport_memory.go
+++ b/daemon/internal/state/transport_memory.go
@@ -1,0 +1,144 @@
+package state
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+)
+
+// maxTransportMemoryEntries caps how many networks are remembered; the
+// least-recently-updated entries are pruned past it. High enough to cover every
+// network a user realistically revisits, low enough to bound the file.
+const maxTransportMemoryEntries = 64
+
+// TransportMemoryEntry records which transport last established a tunnel on a
+// network and when, so the auto-connect cascade can try it first.
+type TransportMemoryEntry struct {
+	Transport string `json:"transport"`
+	UpdatedAt int64  `json:"updatedAt"`
+}
+
+type transportMemoryData struct {
+	Networks map[string]TransportMemoryEntry `json:"networks"`
+}
+
+// TransportMemoryStore is a small persisted map of network key -> last-good
+// transport. It is a best-effort optimization cache, not authoritative config:
+// a missing or corrupt file resets to empty rather than failing, since the
+// cascade always falls back to trying every transport.
+type TransportMemoryStore struct {
+	mu   sync.Mutex
+	path string
+	data transportMemoryData
+	now  func() int64
+}
+
+// NewTransportMemoryStore opens (or creates) the store at path. A corrupt or
+// unreadable file is treated as empty so the daemon still starts.
+func NewTransportMemoryStore(path string) (*TransportMemoryStore, error) {
+	s := &TransportMemoryStore{
+		path: path,
+		data: transportMemoryData{Networks: map[string]TransportMemoryEntry{}},
+		now:  func() int64 { return time.Now().Unix() },
+	}
+	if err := s.loadOrCreate(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// Lookup returns the transport last recorded as working for networkKey, or
+// ("", false) when there is nothing remembered (including an empty key).
+func (s *TransportMemoryStore) Lookup(networkKey string) (string, bool) {
+	if networkKey == "" {
+		return "", false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.data.Networks[networkKey]
+	if !ok || entry.Transport == "" {
+		return "", false
+	}
+	return entry.Transport, true
+}
+
+// Record remembers transport as the last-good for networkKey and persists.
+// No-ops on empty inputs. Prunes least-recently-updated entries past the cap.
+func (s *TransportMemoryStore) Record(networkKey, transport string) error {
+	if networkKey == "" || transport == "" {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data.Networks[networkKey] = TransportMemoryEntry{Transport: transport, UpdatedAt: s.now()}
+	s.pruneLocked()
+	return s.persistLocked()
+}
+
+func (s *TransportMemoryStore) pruneLocked() {
+	if len(s.data.Networks) <= maxTransportMemoryEntries {
+		return
+	}
+	type keyed struct {
+		key       string
+		updatedAt int64
+	}
+	entries := make([]keyed, 0, len(s.data.Networks))
+	for key, entry := range s.data.Networks {
+		entries = append(entries, keyed{key, entry.UpdatedAt})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].updatedAt < entries[j].updatedAt })
+	for i := 0; i < len(entries)-maxTransportMemoryEntries; i++ {
+		delete(s.data.Networks, entries[i].key)
+	}
+}
+
+func (s *TransportMemoryStore) loadOrCreate() error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
+		return fmt.Errorf("create transport memory directory: %w", err)
+	}
+
+	raw, err := os.ReadFile(s.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return s.persistLocked()
+		}
+		// Unreadable cache is non-fatal: start empty.
+		return nil
+	}
+
+	var data transportMemoryData
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &data); err != nil {
+			// Corrupt cache is non-fatal: start empty and rewrite.
+			s.data = transportMemoryData{Networks: map[string]TransportMemoryEntry{}}
+			return s.persistLocked()
+		}
+	}
+	if data.Networks == nil {
+		data.Networks = map[string]TransportMemoryEntry{}
+	}
+	s.data = data
+	return nil
+}
+
+func (s *TransportMemoryStore) persistLocked() error {
+	payload, err := json.MarshalIndent(s.data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal transport memory: %w", err)
+	}
+
+	tmpPath := s.path + ".tmp"
+	if err := os.WriteFile(tmpPath, payload, 0o600); err != nil {
+		return fmt.Errorf("write tmp transport memory: %w", err)
+	}
+	if err := os.Rename(tmpPath, s.path); err != nil {
+		return fmt.Errorf("replace transport memory: %w", err)
+	}
+	return nil
+}

--- a/daemon/internal/state/transport_memory_test.go
+++ b/daemon/internal/state/transport_memory_test.go
@@ -1,0 +1,109 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newTestMemoryStore(t *testing.T) (*TransportMemoryStore, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "transport-memory.json")
+	store, err := NewTransportMemoryStore(path)
+	if err != nil {
+		t.Fatalf("NewTransportMemoryStore: %v", err)
+	}
+	return store, path
+}
+
+func TestTransportMemory_RecordAndLookup(t *testing.T) {
+	store, _ := newTestMemoryStore(t)
+
+	if _, ok := store.Lookup("wifi-a"); ok {
+		t.Fatal("expected no entry before recording")
+	}
+	if err := store.Record("wifi-a", "reality"); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	got, ok := store.Lookup("wifi-a")
+	if !ok || got != "reality" {
+		t.Fatalf("Lookup = (%q, %v), want (reality, true)", got, ok)
+	}
+}
+
+func TestTransportMemory_EmptyInputsAreNoOps(t *testing.T) {
+	store, _ := newTestMemoryStore(t)
+
+	if err := store.Record("", "reality"); err != nil {
+		t.Fatalf("Record empty key: %v", err)
+	}
+	if err := store.Record("wifi-a", ""); err != nil {
+		t.Fatalf("Record empty transport: %v", err)
+	}
+	if _, ok := store.Lookup(""); ok {
+		t.Fatal("empty key should never resolve")
+	}
+	if _, ok := store.Lookup("wifi-a"); ok {
+		t.Fatal("empty transport should not have been stored")
+	}
+}
+
+func TestTransportMemory_PersistsAcrossReload(t *testing.T) {
+	store, path := newTestMemoryStore(t)
+	if err := store.Record("wifi-a", "naive"); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	reopened, err := NewTransportMemoryStore(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	got, ok := reopened.Lookup("wifi-a")
+	if !ok || got != "naive" {
+		t.Fatalf("after reload Lookup = (%q, %v), want (naive, true)", got, ok)
+	}
+}
+
+func TestTransportMemory_PrunesLeastRecentlyUpdated(t *testing.T) {
+	store, _ := newTestMemoryStore(t)
+	// Deterministic, monotonic clock so pruning order is well-defined.
+	var clock int64
+	store.now = func() int64 { clock++; return clock }
+
+	total := maxTransportMemoryEntries + 10
+	for i := 0; i < total; i++ {
+		key := "net-" + string(rune('A'+i%26)) + string(rune('0'+i/26))
+		if err := store.Record(key, "cloak"); err != nil {
+			t.Fatalf("Record %d: %v", i, err)
+		}
+	}
+
+	store.mu.Lock()
+	size := len(store.data.Networks)
+	store.mu.Unlock()
+	if size != maxTransportMemoryEntries {
+		t.Fatalf("store size = %d, want capped at %d", size, maxTransportMemoryEntries)
+	}
+}
+
+func TestTransportMemory_CorruptFileResetsToEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "transport-memory.json")
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatalf("seed corrupt file: %v", err)
+	}
+
+	store, err := NewTransportMemoryStore(path)
+	if err != nil {
+		t.Fatalf("expected corrupt file to be tolerated, got: %v", err)
+	}
+	if _, ok := store.Lookup("anything"); ok {
+		t.Fatal("expected empty store after corrupt load")
+	}
+	// And it should be usable (rewritten) afterward.
+	if err := store.Record("wifi-a", "hysteria2"); err != nil {
+		t.Fatalf("Record after corrupt reset: %v", err)
+	}
+	if got, ok := store.Lookup("wifi-a"); !ok || got != "hysteria2" {
+		t.Fatalf("Lookup = (%q, %v), want (hysteria2, true)", got, ok)
+	}
+}

--- a/daemon/internal/state/types.go
+++ b/daemon/internal/state/types.go
@@ -53,6 +53,11 @@ type WireGuardStatus struct {
 	Detail   string `json:"detail"`
 	BytesIn  int64  `json:"bytesIn"`
 	BytesOut int64  `json:"bytesOut"`
+	// LastHandshakeUnix is the most recent successful WireGuard handshake with
+	// any peer, in Unix seconds; 0 means no handshake has completed yet. The
+	// interface can be Running with no handshake (device up, peer unreached),
+	// which is why connection readiness gates on this, not on Running alone.
+	LastHandshakeUnix int64 `json:"lastHandshakeUnix"`
 }
 
 type StatusResponse struct {

--- a/daemon/internal/wg/darwin.go
+++ b/daemon/internal/wg/darwin.go
@@ -154,12 +154,13 @@ func (m *wireGuardGoManager) statusDarwin(_ context.Context, profile state.WireG
 	tunnelKey := sanitizeTunnelName(profile.TunnelName)
 	if m.hasActiveDevice(tunnelKey) {
 		session, _ := m.session(tunnelKey)
-		rxBytes, txBytes := peerTransferStats(session.device)
+		rxBytes, txBytes, lastHandshake := peerStats(session.device)
 		return state.WireGuardStatus{
-			Running:  true,
-			Detail:   fmt.Sprintf("interface %s running (in-process)", session.interfaceName),
-			BytesIn:  rxBytes,
-			BytesOut: txBytes,
+			Running:           true,
+			Detail:            fmt.Sprintf("interface %s running (in-process)", session.interfaceName),
+			BytesIn:           rxBytes,
+			BytesOut:          txBytes,
+			LastHandshakeUnix: lastHandshake,
 		}, nil
 	}
 

--- a/daemon/internal/wg/darwin_linux_shared.go
+++ b/daemon/internal/wg/darwin_linux_shared.go
@@ -40,9 +40,9 @@ type tunnelSession struct {
 	// Networking state for cleanup.
 	endpointRoutes   []routeSpec
 	dnsOverrides     []darwinDNSOverride // macOS
-	linuxDNSOverride *linuxDNSOverride // Linux
-	linuxAllowedIPs  []string          // Linux: for policy routing cleanup
-	windowsLUID      uint64            // Windows
+	linuxDNSOverride *linuxDNSOverride   // Linux
+	linuxAllowedIPs  []string            // Linux: for policy routing cleanup
+	windowsLUID      uint64              // Windows
 	windowsRoutes    []windowsRouteSpec  // Windows endpoint bypass routes
 }
 
@@ -185,27 +185,35 @@ func (m *wireGuardGoManager) session(tunnelKey string) (*tunnelSession, bool) {
 	return s, ok
 }
 
-// peerTransferStats reads aggregate rx/tx bytes from all peers via UAPI.
-func peerTransferStats(dev *device.Device) (rxBytes, txBytes int64) {
+// peerStats reads aggregate rx/tx bytes and the most recent peer handshake
+// time (Unix seconds; 0 if no peer has ever handshaked) from all peers via
+// UAPI. WireGuard's UAPI dump reports these per peer; we sum the byte counters
+// and take the newest handshake across peers.
+func peerStats(dev *device.Device) (rxBytes, txBytes, lastHandshakeUnix int64) {
 	if dev == nil {
-		return 0, 0
+		return 0, 0, 0
 	}
 	ipcData, err := dev.IpcGet()
 	if err != nil {
-		return 0, 0
+		return 0, 0, 0
 	}
 	for _, line := range strings.Split(ipcData, "\n") {
-		if strings.HasPrefix(line, "rx_bytes=") {
-			if v, err := strconv.ParseInt(line[9:], 10, 64); err == nil {
+		switch {
+		case strings.HasPrefix(line, "rx_bytes="):
+			if v, err := strconv.ParseInt(line[len("rx_bytes="):], 10, 64); err == nil {
 				rxBytes += v
 			}
-		} else if strings.HasPrefix(line, "tx_bytes=") {
-			if v, err := strconv.ParseInt(line[9:], 10, 64); err == nil {
+		case strings.HasPrefix(line, "tx_bytes="):
+			if v, err := strconv.ParseInt(line[len("tx_bytes="):], 10, 64); err == nil {
 				txBytes += v
+			}
+		case strings.HasPrefix(line, "last_handshake_time_sec="):
+			if v, err := strconv.ParseInt(line[len("last_handshake_time_sec="):], 10, 64); err == nil && v > lastHandshakeUnix {
+				lastHandshakeUnix = v
 			}
 		}
 	}
-	return rxBytes, txBytes
+	return rxBytes, txBytes, lastHandshakeUnix
 }
 
 func (m *wireGuardGoManager) storeSession(tunnelKey string, s *tunnelSession) {
@@ -579,4 +587,3 @@ func resolveHostIPs(ctx context.Context, host string) []net.IP {
 	}
 	return ips
 }
-

--- a/daemon/internal/wg/linux.go
+++ b/daemon/internal/wg/linux.go
@@ -172,12 +172,13 @@ func (m *wireGuardGoManager) statusLinux(_ context.Context, profile state.WireGu
 	tunnelKey := sanitizeTunnelName(profile.TunnelName)
 	if m.hasActiveDevice(tunnelKey) {
 		session, _ := m.session(tunnelKey)
-		rxBytes, txBytes := peerTransferStats(session.device)
+		rxBytes, txBytes, lastHandshake := peerStats(session.device)
 		return state.WireGuardStatus{
-			Running:  true,
-			Detail:   fmt.Sprintf("interface %s running (in-process)", session.interfaceName),
-			BytesIn:  rxBytes,
-			BytesOut: txBytes,
+			Running:           true,
+			Detail:            fmt.Sprintf("interface %s running (in-process)", session.interfaceName),
+			BytesIn:           rxBytes,
+			BytesOut:          txBytes,
+			LastHandshakeUnix: lastHandshake,
 		}, nil
 	}
 

--- a/daemon/internal/wg/windows.go
+++ b/daemon/internal/wg/windows.go
@@ -154,12 +154,13 @@ func (m *wireGuardGoManager) statusWindows(_ context.Context, profile state.Wire
 	tunnelKey := sanitizeTunnelName(profile.TunnelName)
 	if m.hasActiveDevice(tunnelKey) {
 		session, _ := m.session(tunnelKey)
-		rxBytes, txBytes := peerTransferStats(session.device)
+		rxBytes, txBytes, lastHandshake := peerStats(session.device)
 		return state.WireGuardStatus{
-			Running:  true,
-			Detail:   fmt.Sprintf("interface %s running (in-process)", session.interfaceName),
-			BytesIn:  rxBytes,
-			BytesOut: txBytes,
+			Running:           true,
+			Detail:            fmt.Sprintf("interface %s running (in-process)", session.interfaceName),
+			BytesIn:           rxBytes,
+			BytesOut:          txBytes,
+			LastHandshakeUnix: lastHandshake,
 		}, nil
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pangea-vpn",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pangea-vpn",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "@pangeavpn/desktop",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@pangeavpn/shared-types": "file:../../packages/shared-types",
         "electron-updater": "^6.8.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pangea-vpn",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/scripts/build-bin/mac.mjs
+++ b/scripts/build-bin/mac.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 import process from "node:process";
 import { spawnSync } from "node:child_process";
 import { npmCmd, relPath, rootDir, runOrThrow, sha256File, writeJson } from "./shared.mjs";
+import { resolveNaiveCgoConfig } from "../lib/naive-cgo.mjs";
 
 const platformName = "mac";
 const daemonDir = path.join(rootDir, "daemon");
@@ -137,14 +138,21 @@ async function copyStandaloneMacTools() {
 
 function buildDaemon(goArch, outPath) {
   // with_utls is required by the VLESS+REALITY transport (sing-box compiles
-  // uTLS out by default). naive_cgo is Windows-only, so macOS needs only this.
-  runOrThrow(goCmd, ["build", "-tags", "with_utls", "-o", outPath, "./cmd/daemon"], {
+  // uTLS out by default). naive_cgo is added on top when the pangea_naive
+  // archive + toolchain resolve; otherwise the stub transport builds.
+  const naiveCgo = resolveNaiveCgoConfig(goArch, rootDir);
+  if (naiveCgo) {
+    console.log(`naive_cgo: enabled for ${goArch} (pangea_naive lib found and toolchain resolved)`);
+  }
+  const buildTags = ["with_utls", ...(naiveCgo ? naiveCgo.tags : [])];
+  runOrThrow(goCmd, ["build", "-tags", buildTags.join(","), "-o", outPath, "./cmd/daemon"], {
     cwd: daemonDir,
     shell: false,
     env: {
       ...goEnv(),
       GOOS: "darwin",
-      GOARCH: goArch
+      GOARCH: goArch,
+      ...(naiveCgo ? naiveCgo.env : {})
     }
   });
 }

--- a/scripts/build-daemon.mjs
+++ b/scripts/build-daemon.mjs
@@ -20,9 +20,9 @@ if (!goCmd) {
 // GOARCH is set by scripts/build-bin/windows.mjs per target (amd64/arm64);
 // falls back to the host arch for local `node build-daemon.mjs` runs.
 const goArch = process.env.GOARCH || (process.arch === "arm64" ? "arm64" : "amd64");
-const naiveCgo = isWin ? resolveNaiveCgoConfig(goArch, rootDir) : null;
+const naiveCgo = resolveNaiveCgoConfig(goArch, rootDir);
 if (naiveCgo) {
-  console.log(`naive_cgo: enabled for ${goArch} (pangea_naive.lib found and toolchain resolved)`);
+  console.log(`naive_cgo: enabled for ${goArch} (pangea_naive lib found and toolchain resolved)`);
 }
 
 const env = goEnv(rootDir, naiveCgo);

--- a/scripts/install-mac.sh
+++ b/scripts/install-mac.sh
@@ -11,7 +11,7 @@
 set -euo pipefail
 
 # ── Configuration ────────────────────────────────────────────────────────────
-VERSION="0.4.2"
+VERSION="0.4.3"
 
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'

--- a/scripts/lib/naive-cgo-darwin.mjs
+++ b/scripts/lib/naive-cgo-darwin.mjs
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { ensurePangeaNaiveLib } from "./naive-download.mjs";
+
+// The mac frameworks the pangea_naive archive's objects reference, read off
+// the is_apple/is_mac `frameworks` declarations of the GN targets bundled
+// into the complete_static_lib (base, net, crypto, partition_alloc) — the
+// darwin analog of WINDOWS_SYSTEM_LIBS in naive-cgo.mjs.
+const MAC_FRAMEWORKS = [
+  "AppKit", "ApplicationServices", "CFNetwork", "CoreFoundation",
+  "CoreGraphics", "CoreServices", "CoreText", "CryptoTokenKit", "Foundation",
+  "IOKit", "LocalAuthentication", "Network", "OpenCL", "OpenDirectory",
+  "Security", "SystemConfiguration", "UniformTypeIdentifiers"
+];
+
+// net's is_mac block additionally links libresolv.
+const MAC_LIBS = ["-lresolv"];
+
+// Matches mac_deployment_target in the fork's build/config/mac/mac_sdk.gni.
+const MAC_DEPLOYMENT_TARGET = "12.0";
+
+const CLANG_ARCH = { amd64: "x86_64", arm64: "arm64" };
+const LOCAL_OUT_DIR = { amd64: "pangea-mac-x64", arm64: "pangea-mac-arm64" };
+
+// Darwin counterpart of the Windows resolver in naive-cgo.mjs: resolves the
+// lib + header (a local fork build tree if present, else the pinned
+// prebuilt) and returns the cgo build config, or null (after logging why)
+// so callers fall back to the stub transport. Unlike Windows this needs no
+// CC wrapper or MSVC env capture — Apple clang is cgo's default CC; the
+// -arch flags make the x64 cross-build from the arm64 CI host work.
+export function resolveNaiveCgoConfigDarwin(goArch, rootDir) {
+  const clangArch = CLANG_ARCH[goArch];
+  const localOutDir = LOCAL_OUT_DIR[goArch];
+  if (!clangArch || !localOutDir) {
+    return null;
+  }
+
+  const naiveproxySrc =
+    process.env.PANGEA_NAIVEPROXY_SRC || path.join(rootDir, "..", "naiveproxy", "src");
+
+  let libDir = path.join(naiveproxySrc, "out", localOutDir, "obj", "net");
+  let headerDir = path.join(naiveproxySrc, "pangea", "capi");
+  let libName = "libpangea_naive.a";
+  const headerName = "pangea_naive_capi.h";
+  if (!fs.existsSync(path.join(libDir, libName)) || !fs.existsSync(path.join(headerDir, headerName))) {
+    const prebuilt = ensurePangeaNaiveLib(goArch, rootDir);
+    if (!prebuilt) {
+      console.warn(
+        `naive_cgo: no local build at ${libDir} and no pinned prebuilt available; ` +
+          `naive transport falls back to the stub for ${goArch}.`
+      );
+      return null;
+    }
+    libDir = prebuilt.libDir;
+    headerDir = prebuilt.headerDir;
+    libName = prebuilt.libName;
+  }
+
+  const archFlags = `-arch ${clangArch} -mmacosx-version-min=${MAC_DEPLOYMENT_TARGET}`;
+  return {
+    tags: ["naive_cgo"],
+    env: {
+      CGO_ENABLED: "1",
+      CGO_CFLAGS: `-I${headerDir} ${archFlags}`,
+      CGO_LDFLAGS: [
+        `-L${libDir}`,
+        "-lpangea_naive",
+        ...MAC_LIBS,
+        ...MAC_FRAMEWORKS.map((name) => `-framework ${name}`),
+        archFlags
+      ].join(" ")
+    }
+  };
+}

--- a/scripts/lib/naive-cgo.mjs
+++ b/scripts/lib/naive-cgo.mjs
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
+import { resolveNaiveCgoConfigDarwin } from "./naive-cgo-darwin.mjs";
 import { ensurePangeaNaiveLib } from "./naive-download.mjs";
 
 // The Windows default_libs list Chromium executables get automatically
@@ -27,14 +28,15 @@ const CLANG_TARGET = { amd64: "x86_64-pc-windows-msvc", arm64: "aarch64-pc-windo
 const VCVARS_ARCH = { amd64: "x64", arm64: "arm64" };
 
 // Resolves the naive_cgo build config for the given Go arch ("amd64" |
-// "arm64"). Returns null (after logging why) if the naiveproxy fork's
-// build artifacts or the matching pinned toolchain aren't available on
-// this machine — callers should fall back to building without the
-// naive_cgo tag (the stub transport) rather than failing the build, since
-// most dev machines and CI runners won't have this multi-GB toolchain set
-// up. See the naiveproxy transport design for the one-time machine setup
-// this depends on.
+// "arm64") on the current platform (Windows here, darwin via
+// naive-cgo-darwin.mjs). Returns null (after logging why) if the naiveproxy
+// fork's build artifacts or a usable toolchain aren't available on this
+// machine — callers should fall back to building without the naive_cgo tag
+// (the stub transport) rather than failing the build.
 export function resolveNaiveCgoConfig(goArch, rootDir) {
+  if (process.platform === "darwin") {
+    return resolveNaiveCgoConfigDarwin(goArch, rootDir);
+  }
   if (process.platform !== "win32") {
     return null;
   }
@@ -49,27 +51,13 @@ export function resolveNaiveCgoConfig(goArch, rootDir) {
   const naiveproxySrc =
     process.env.PANGEA_NAIVEPROXY_SRC || path.join(rootDir, "..", "naiveproxy", "src");
 
+  // Resolve the lib + header: a local Chromium build tree if present, else the
+  // pinned prebuilt fetched from the fork's release. The prebuilt is native
+  // COFF (built with use_thin_lto=false), so it links against any recent
+  // clang-cl — no longer only the exact pinned Chromium toolchain.
   let libPath = path.join(naiveproxySrc, "out", gnArchDir, "obj", "net", "pangea_naive.lib");
   let headerDir = path.join(naiveproxySrc, "pangea", "capi");
   let headerPath = path.join(headerDir, "pangea_naive_capi.h");
-  const llvmBinDir = path.join(naiveproxySrc, "third_party", "llvm-build", "Release+Asserts", "bin");
-  const clangClPath = path.join(llvmBinDir, "clang-cl.exe");
-  const clangPath = path.join(llvmBinDir, "clang.exe");
-
-  // No pinned clang = nothing to link the lib against; bail before downloading.
-  if (!fs.existsSync(clangClPath)) {
-    console.warn(
-      `naive_cgo: pinned clang-cl.exe not found at ${clangClPath}; naive transport falls back to the stub for ${goArch}.`
-    );
-    return null;
-  }
-  if (!fs.existsSync(clangPath)) {
-    // clang.exe (argv[0] driver detection) gives GCC-style flags from the
-    // pinned toolchain; LTO bitcode must match that exact revision.
-    fs.copyFileSync(clangClPath, clangPath);
-  }
-
-  // Prefer a local build; else fetch the pinned prebuilt from the release.
   if (!fs.existsSync(libPath) || !fs.existsSync(headerPath)) {
     const prebuilt = ensurePangeaNaiveLib(goArch, rootDir);
     if (!prebuilt) {
@@ -79,9 +67,20 @@ export function resolveNaiveCgoConfig(goArch, rootDir) {
       );
       return null;
     }
-    libPath = path.join(prebuilt.libDir, "pangea_naive.lib");
+    libPath = path.join(prebuilt.libDir, prebuilt.libName);
     headerDir = prebuilt.headerDir;
     headerPath = path.join(headerDir, "pangea_naive_capi.h");
+  }
+
+  // Resolve a clang for cgo's compile+link: the pinned Chromium clang from a
+  // local checkout if present, else a system clang-cl (LLVM is preinstalled on
+  // CI runners). Native-COFF pangea_naive.lib links against either.
+  const clangPath = resolveClang(naiveproxySrc);
+  if (!clangPath) {
+    console.warn(
+      `naive_cgo: no clang-cl found (pinned toolchain or system LLVM); naive transport falls back to the stub for ${goArch}.`
+    );
+    return null;
   }
 
   const vcvars = findVcvarsEnv(vcvarsArch);
@@ -123,6 +122,48 @@ function toForwardSlash(p) {
   return p.replaceAll("\\", "/");
 }
 
+// Resolves a clang.exe (the GCC-style driver name cgo invokes) for the CC
+// wrapper. Prefers the pinned Chromium toolchain from a local naiveproxy
+// checkout; else falls back to a system clang-cl via PANGEA_CLANG_CL, the
+// default LLVM install dir, or PATH. Returns the clang.exe path, or null when
+// none is found. Native-COFF pangea_naive.lib links against any recent clang.
+function resolveClang(naiveproxySrc) {
+  const pinnedBin = path.join(naiveproxySrc, "third_party", "llvm-build", "Release+Asserts", "bin");
+  const candidates = [
+    path.join(pinnedBin, "clang-cl.exe"),
+    process.env.PANGEA_CLANG_CL,
+    path.join(process.env.ProgramFiles ?? "C:\\Program Files", "LLVM", "bin", "clang-cl.exe"),
+    whichExe("clang-cl.exe")
+  ];
+  for (const clangCl of candidates) {
+    if (clangCl && fs.existsSync(clangCl)) {
+      return ensureClangDriver(path.dirname(clangCl), clangCl);
+    }
+  }
+  return null;
+}
+
+// clang.exe and clang-cl.exe are the same binary; cgo invokes it as clang.exe
+// (argv[0] selects the GCC-style driver). Returns an existing sibling
+// clang.exe, else copies clang-cl.exe to one (the pinned toolchain dir is
+// writable; the system LLVM dir already ships clang.exe, so no copy needed).
+function ensureClangDriver(binDir, clangClPath) {
+  const clangPath = path.join(binDir, "clang.exe");
+  if (!fs.existsSync(clangPath)) {
+    fs.copyFileSync(clangClPath, clangPath);
+  }
+  return clangPath;
+}
+
+// Minimal PATH lookup for an executable; returns its full path or null.
+function whichExe(exe) {
+  const result = spawnSync("where", [exe], { encoding: "utf8", shell: false });
+  if (result.error || (result.status ?? 1) !== 0) {
+    return null;
+  }
+  return result.stdout.split(/\r?\n/).map((s) => s.trim()).find(Boolean) || null;
+}
+
 // Builds (or reuses a cached) naive-cc-wrapper.exe — see
 // scripts/naive-cc-wrapper/main.go for what it does and why it must be a
 // real compiled executable rather than a .bat/.cmd file (Go's os/exec
@@ -150,35 +191,11 @@ function buildCcWrapper(rootDir) {
   return outPath;
 }
 
-// Locates vcvarsall.bat across common Visual Studio 2022 editions/install
-// roots and runs it to capture INCLUDE/LIB for the given architecture
-// ("x64" | "arm64"). Does not rely on any prior interactive setup.
+// Locates vcvarsall.bat and runs it to capture INCLUDE/LIB for the given
+// architecture ("x64" | "arm64"). Does not rely on any prior interactive
+// setup.
 function findVcvarsEnv(arch) {
-  const roots = [
-    process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)",
-    process.env["ProgramFiles"] ?? "C:\\Program Files"
-  ];
-  const editions = ["BuildTools", "Community", "Professional", "Enterprise"];
-
-  let vcvarsallPath = null;
-  outer: for (const root of roots) {
-    for (const edition of editions) {
-      const candidate = path.join(
-        root,
-        "Microsoft Visual Studio",
-        "2022",
-        edition,
-        "VC",
-        "Auxiliary",
-        "Build",
-        "vcvarsall.bat"
-      );
-      if (fs.existsSync(candidate)) {
-        vcvarsallPath = candidate;
-        break outer;
-      }
-    }
-  }
+  const vcvarsallPath = findVcvarsall();
   if (!vcvarsallPath) {
     return null;
   }
@@ -204,4 +221,49 @@ function findVcvarsEnv(arch) {
     return null;
   }
   return env;
+}
+
+// Finds vcvarsall.bat via vswhere (any VS version/edition — VS 2026 installs
+// under a major-version root like "...\Microsoft Visual Studio\18\Enterprise",
+// not a year), with a static probe of known install dirs as fallback.
+function findVcvarsall() {
+  const pf86 = process.env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)";
+  const vswhere = path.join(pf86, "Microsoft Visual Studio", "Installer", "vswhere.exe");
+  if (fs.existsSync(vswhere)) {
+    const result = spawnSync(
+      vswhere,
+      ["-latest", "-products", "*", "-find", "VC\\Auxiliary\\Build\\vcvarsall.bat"],
+      { encoding: "utf8", shell: false }
+    );
+    if (!result.error && (result.status ?? 1) === 0) {
+      const found = result.stdout.split(/\r?\n/).map((s) => s.trim()).find(Boolean);
+      if (found && fs.existsSync(found)) {
+        return found;
+      }
+    }
+  }
+
+  const roots = [pf86, process.env["ProgramFiles"] ?? "C:\\Program Files"];
+  const versions = ["2022", "18"];
+  const editions = ["BuildTools", "Community", "Professional", "Enterprise", "Insiders"];
+  for (const root of roots) {
+    for (const version of versions) {
+      for (const edition of editions) {
+        const candidate = path.join(
+          root,
+          "Microsoft Visual Studio",
+          version,
+          edition,
+          "VC",
+          "Auxiliary",
+          "Build",
+          "vcvarsall.bat"
+        );
+        if (fs.existsSync(candidate)) {
+          return candidate;
+        }
+      }
+    }
+  }
+  return null;
 }

--- a/scripts/lib/naive-download.mjs
+++ b/scripts/lib/naive-download.mjs
@@ -2,37 +2,55 @@ import { spawnSync } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import process from "node:process";
 
 // Pinned prebuilt pangea_naive engine (lib + header) from the fork's public
 // release, so the daemon build skips a local Chromium build. Bump on re-release.
 const RELEASE_REPO = "pangeavpn/naiveproxy";
-const RELEASE_TAG = "pangea-naive-v150.0.7871.63-1";
+const RELEASE_TAG = "pangea-naive-v150.0.7871.63-3";
 
 // goArch ("amd64" | "arm64") -> the CI matrix arch in the release asset name.
 const ASSET_ARCH = { amd64: "x64", arm64: "arm64" };
 
-// sha256 of pangea-naive-<arch>.zip; empty entry falls back to HTTPS trust.
-const ASSET_SHA256 = {
-  // x64: "...",
-  // arm64: "...",
+// Per-OS asset naming: Windows zips hold a COFF pangea_naive.lib, mac zips a
+// Mach-O libpangea_naive.a.
+const OS_ASSET = {
+  win32: { prefix: "pangea-naive-", libName: "pangea_naive.lib" },
+  darwin: { prefix: "pangea-naive-mac-", libName: "libpangea_naive.a" }
 };
 
-// ensurePangeaNaiveLib returns { libDir, headerDir } for the pinned prebuilt,
-// downloading + caching under .cache on first use, or null if it can't fetch.
+// sha256 of <prefix><arch>.zip; empty entry falls back to HTTPS trust.
+const ASSET_SHA256 = {
+  win32: {
+    x64: "cc932c0d19cb95fa6deb85765d087ecf89db3821bf34c9af1f0b6df8bd525591",
+    arm64: "8fc336d4e845c58d7ed9e5cfe500fadb936cde2e329d593e1762d6aebd52ab2f"
+  },
+  // Fill once the fork's mac jobs publish pangea-naive-mac-<arch>.zip.
+  darwin: {
+    x64: "",
+    arm64: ""
+  }
+};
+
+// ensurePangeaNaiveLib returns { libDir, headerDir, libName } for the pinned
+// prebuilt, downloading + caching under .cache on first use, or null if it
+// can't fetch.
 export function ensurePangeaNaiveLib(goArch, rootDir) {
   const assetArch = ASSET_ARCH[goArch];
-  if (!assetArch) {
+  const osAsset = OS_ASSET[process.platform];
+  if (!assetArch || !osAsset) {
     return null;
   }
 
-  const cacheDir = path.join(rootDir, ".cache", "pangea-naive", RELEASE_TAG, assetArch);
-  const libPath = path.join(cacheDir, "pangea_naive.lib");
+  const assetStem = `${osAsset.prefix}${assetArch}`;
+  const cacheDir = path.join(rootDir, ".cache", "pangea-naive", RELEASE_TAG, assetStem);
+  const libPath = path.join(cacheDir, osAsset.libName);
   const headerPath = path.join(cacheDir, "pangea_naive_capi.h");
   if (fs.existsSync(libPath) && fs.existsSync(headerPath)) {
-    return { libDir: cacheDir, headerDir: cacheDir };
+    return { libDir: cacheDir, headerDir: cacheDir, libName: osAsset.libName };
   }
 
-  const asset = `pangea-naive-${assetArch}.zip`;
+  const asset = `${assetStem}.zip`;
   const url = `https://github.com/${RELEASE_REPO}/releases/download/${RELEASE_TAG}/${asset}`;
   fs.mkdirSync(cacheDir, { recursive: true });
   const zipPath = path.join(cacheDir, asset);
@@ -47,7 +65,7 @@ export function ensurePangeaNaiveLib(goArch, rootDir) {
     return null;
   }
 
-  const expectedSha = ASSET_SHA256[assetArch];
+  const expectedSha = (ASSET_SHA256[process.platform] ?? {})[assetArch];
   if (expectedSha) {
     const actual = sha256File(zipPath);
     if (actual !== expectedSha) {
@@ -59,15 +77,14 @@ export function ensurePangeaNaiveLib(goArch, rootDir) {
     console.warn(`naive_cgo: no sha256 pin configured for ${asset}; trusting HTTPS only.`);
   }
 
-  // tar (bsdtar) extracts the .zip; it holds a top pangea-naive-<arch>/ dir.
-  const untar = spawnSync("tar", ["-xf", zipPath, "-C", cacheDir], { stdio: "inherit", shell: false });
-  if (untar.error || (untar.status ?? 1) !== 0) {
+  // The .zip holds a top <assetStem>/ dir.
+  if (!extractZip(zipPath, cacheDir)) {
     console.warn(`naive_cgo: failed to extract ${asset}; naive transport falls back to the stub for ${goArch}.`);
     return null;
   }
 
-  const extractedDir = path.join(cacheDir, `pangea-naive-${assetArch}`);
-  for (const name of ["pangea_naive.lib", "pangea_naive_capi.h"]) {
+  const extractedDir = path.join(cacheDir, assetStem);
+  for (const name of [osAsset.libName, "pangea_naive_capi.h"]) {
     const src = path.join(extractedDir, name);
     const dst = path.join(cacheDir, name);
     if (fs.existsSync(src)) {
@@ -81,11 +98,36 @@ export function ensurePangeaNaiveLib(goArch, rootDir) {
     console.warn(`naive_cgo: ${asset} did not contain the expected lib/header; falling back to the stub for ${goArch}.`);
     return null;
   }
-  return { libDir: cacheDir, headerDir: cacheDir };
+  return { libDir: cacheDir, headerDir: cacheDir, libName: osAsset.libName };
 }
 
 function sha256File(filePath) {
   const hash = crypto.createHash("sha256");
   hash.update(fs.readFileSync(filePath));
   return hash.digest("hex");
+}
+
+// Extracts a .zip into destDir. Prefers tar (bsdtar handles zip; the default
+// tar on macOS and Windows), falls back to PowerShell Expand-Archive on
+// Windows — GNU tar (some Git-for-Windows shells) can't read zips. Returns
+// true on success.
+function extractZip(zipPath, destDir) {
+  const bsd = spawnSync("tar", ["-xf", zipPath, "-C", destDir], { stdio: "inherit", shell: false });
+  if (!bsd.error && (bsd.status ?? 1) === 0) {
+    return true;
+  }
+  if (process.platform !== "win32") {
+    return false;
+  }
+  const ps = spawnSync(
+    "powershell",
+    [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      `Expand-Archive -Path '${zipPath}' -DestinationPath '${destDir}' -Force`
+    ],
+    { stdio: "inherit", shell: false }
+  );
+  return !ps.error && (ps.status ?? 1) === 0;
 }

--- a/scripts/naive-cc-wrapper/main.go
+++ b/scripts/naive-cc-wrapper/main.go
@@ -1,19 +1,16 @@
-// naive-cc-wrapper adapts the naiveproxy fork's pinned clang (a Chromium
-// clang-cl build, copied to clang.exe to get GCC-style flags — see
-// the naiveproxy transport design's
-// "Known risk" section for why this exact toolchain, not any clang on
-// PATH, is required) for use as Go's CGO CC on Windows:
+// naive-cc-wrapper adapts a clang-cl build (copied to clang.exe to get
+// GCC-style flags) for use as Go's CGO CC on Windows:
 //
 //   - strips -mthreads, which Go's cgo unconditionally injects for
 //     GOOS=windows builds and which this MSVC-target clang rejects.
-//   - adds --target=<NAIVE_CC_TARGET> and -fuse-ld=lld so the linker
-//     matches the clang revision that built pangea_naive.lib (mismatched
-//     LTO bitcode versions fail to link).
+//   - adds --target=<NAIVE_CC_TARGET> and -fuse-ld=lld to link with lld.
 //
-// Configured entirely via environment variables so one compiled binary
-// works for either Windows target architecture:
+// pangea_naive.lib is native COFF (built with use_thin_lto=false), so any
+// recent clang links it — either the pinned Chromium toolchain from a local
+// checkout or a stock system LLVM. Configured entirely via environment
+// variables so one compiled binary works for either Windows target arch:
 //
-//	NAIVE_CC_REAL_CC     path to the pinned toolchain's clang.exe
+//	NAIVE_CC_REAL_CC     path to a clang.exe (pinned toolchain or system LLVM)
 //	NAIVE_CC_TARGET      e.g. aarch64-pc-windows-msvc or x86_64-pc-windows-msvc
 package main
 


### PR DESCRIPTION
## Summary

Hardens the transport/connection layer and extends the NaiveProxy transport to macOS. Three commits.

### `feat(daemon)` — connection readiness & transport selection
- **"Connected" now requires a real WireGuard handshake**, not just an up interface. The daemon reads `last_handshake_time` from the UAPI dump and waits for it before reporting `CONNECTED`, so a started-but-dead tunnel never shows connected. The GUI follows automatically (it mirrors daemon state).
- **The handshake drives fallback.** A transport whose server never completes a handshake is torn down and the next is tried — WireGuard bring-up moved inside each per-transport attempt. This also validates Cloak, which can't prove its own session at start time.
- **Health check** flags a tunnel that goes silent mid-session (no handshake within the stale window).
- **Per-network transport memory.** Remembers the transport that last established a tunnel, keyed by a network fingerprint (host interface addresses), and tries it first on the next auto-connect. Persisted, LRU-capped, corruption-tolerant.
- **Auto-cascade reordered** for censorship resistance rather than build order: `cloak → reality → hysteria2 → naive → snowflake`.

### `build(daemon)` — naive_cgo on CI Windows + macOS
Locates vcvars via `vswhere` (the VS 2026 runner image has no VS 2022), links the native-COFF prebuilt `pangea_naive.lib` against stock clang-cl / system LLVM, pins the `-3` release sha256s, and adds a darwin resolver plus platform-aware asset download so the transport builds on macOS too.

### `chore` — version bump to 0.4.3

## Testing
- Full daemon `internal/...` suite green; `go vet` clean; cross-compiles for windows/linux/darwin.
- New coverage: handshake gating, handshake-driven fallback, stale-handshake health check, the transport-memory store (record / lookup / persist / prune / corrupt-recovery), memory-driven reorder + re-record, and a pinned cascade-order test.

## Follow-ups
- The handshake gate assumes the hub-issued WireGuard config sets `PersistentKeepalive` (needed to initiate a handshake without user traffic — Cloak already depends on it). Worth confirming against a live server.
- macOS naive assets (`pangea-naive-mac-*.zip`) still need building and publishing to the `pangea-naive-v150.0.7871.63-3` release before the darwin sha256 pins can be filled; until then mac naive falls back to the stub gracefully.
