### PR TITLE
fix(daemon): keep the Windows tunnel alive and make its rebuild equivalent to a reconnect

### DIFF
--- a/daemon/internal/api/route_guard.go
+++ b/daemon/internal/api/route_guard.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pangeavpn/pangeavpn-desktop/daemon/internal/state"
+)
+
+// maxEndpointRouteRepairDeferrals bounds how many ticks in a row a repair may
+// hold the recovery path off. A route that settles needs one; one that keeps
+// changing (two default routes trading places, something else rewriting the
+// table) must not be able to suppress the silence detector indefinitely.
+const maxEndpointRouteRepairDeferrals = 3
+
+// ensureEndpointRoutes re-pins the routes that carry WireGuard to its node, and
+// reports whether the caller should give the repair a tick to take effect.
+//
+// Those routes are the tunnel's only way out, and they hang off a gateway that
+// the OS can drop or move mid-session. When that happens the handshakes are
+// routed into the tunnel they are trying to establish and the session goes
+// silent with every layer below still reporting healthy, so it has to be
+// checked from out here.
+func (s *Service) ensureEndpointRoutes(ctx context.Context, profile state.Profile) bool {
+	guard, ok := s.wg.(wgRouteGuard)
+	if !ok {
+		return false
+	}
+
+	repaired, err := guard.EnsureEndpointRoutes(ctx, profile.WireGuard)
+	if err != nil {
+		s.logs.Add(state.LogWarn, state.SourceDaemon, fmt.Sprintf("could not verify the tunnel's endpoint routes: %v", err))
+	}
+	if !repaired {
+		s.recordEndpointRoutesSettled()
+		return false
+	}
+
+	s.logs.Add(state.LogWarn, state.SourceDaemon, "the route carrying the tunnel to its node was missing or pointed at the wrong gateway; re-pinned it")
+	if repairs := s.recordEndpointRouteRepair(); repairs > maxEndpointRouteRepairDeferrals {
+		s.logs.Add(state.LogWarn, state.SourceDaemon, fmt.Sprintf(
+			"the tunnel's endpoint route has needed re-pinning %d health checks running; letting the usual recovery run", repairs))
+		return false
+	}
+	return true
+}
+
+// recordEndpointRouteRepair books a repair and reports how many have run back
+// to back.
+func (s *Service) recordEndpointRouteRepair() int {
+	s.recoveryMu.Lock()
+	defer s.recoveryMu.Unlock()
+	s.endpointRouteRepairs++
+	return s.endpointRouteRepairs
+}
+
+func (s *Service) recordEndpointRoutesSettled() {
+	s.recoveryMu.Lock()
+	defer s.recoveryMu.Unlock()
+	s.endpointRouteRepairs = 0
+}

--- a/daemon/internal/api/route_guard_test.go
+++ b/daemon/internal/api/route_guard_test.go
@@ -1,0 +1,162 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/pangeavpn/pangeavpn-desktop/daemon/internal/state"
+)
+
+// connectedRouteGuardService is a connected naive session, ready to have its
+// health checked tick by tick.
+func connectedRouteGuardService(t *testing.T) (*Service, *fakeWGManager, *fakeNaiveManager) {
+	t.Helper()
+	naive := &fakeNaiveManager{}
+	wgMgr := &fakeWGManager{}
+	svc := newTestService(t, &fakeCloakManager{}, naive, wgMgr, &fakeKillSwitch{}, silentTunnelProfile())
+
+	if err := svc.Connect(context.Background(), "p1", ConnectOptions{PreferredTransport: "naive"}); err != nil {
+		t.Fatalf("connect failed: %v", err)
+	}
+	return svc, wgMgr, naive
+}
+
+// TestHealthCheck_EndpointRoutesCheckedEveryTick proves the route carrying
+// WireGuard to its node is verified continuously rather than only at bring-up.
+// The OS can drop it on a media-sense flap or move the gateway under it, and
+// nothing inside the tunnel can see that.
+func TestHealthCheck_EndpointRoutesCheckedEveryTick(t *testing.T) {
+	svc, wgMgr, _ := connectedRouteGuardService(t)
+
+	wgMgr.mu.Lock()
+	callsAfterConnect := wgMgr.routeGuardCalls
+	wgMgr.mu.Unlock()
+
+	for range 4 {
+		svc.runHealthCheck(context.Background())
+	}
+
+	wgMgr.mu.Lock()
+	calls := wgMgr.routeGuardCalls - callsAfterConnect
+	wgMgr.mu.Unlock()
+	if calls != 4 {
+		t.Errorf("endpoint route guard calls = %d across 4 health checks, want 4", calls)
+	}
+}
+
+// TestHealthCheck_RepairedEndpointRouteIsPreferredOverARebuild proves a silent
+// tunnel whose bypass route was lost gets the route back instead of a full
+// session rebuild. Rewriting the route restores the same session in one tick;
+// the rebuild drops the tunnel, restarts the transport, and re-arms the
+// firewall to reach the same place.
+func TestHealthCheck_RepairedEndpointRouteIsPreferredOverARebuild(t *testing.T) {
+	svc, wgMgr, naive := connectedRouteGuardService(t)
+
+	wgMgr.mu.Lock()
+	startsAfterConnect := wgMgr.startCount
+	wgMgr.routeGuardRepaired = true
+	wgMgr.mu.Unlock()
+
+	goSilent(wgMgr)
+	svc.runHealthCheck(context.Background())
+
+	wgMgr.mu.Lock()
+	restarts := wgMgr.startCount - startsAfterConnect
+	wgMgr.mu.Unlock()
+	if restarts != 0 {
+		t.Errorf("wireguard restarts = %d, want 0 — a re-pinned route is given the tick to handshake on", restarts)
+	}
+	naive.mu.Lock()
+	stopped := naive.stopCalled
+	naive.mu.Unlock()
+	if stopped {
+		t.Error("transport was restarted; re-pinning the route should not disturb the session")
+	}
+	if st := svc.Status(context.Background()).State; st != state.StateConnected {
+		t.Errorf("state = %q, want CONNECTED", st)
+	}
+
+	var repairs int
+	for _, entry := range svc.Logs(0) {
+		if strings.Contains(entry.Msg, "re-pinned it") {
+			repairs++
+		}
+	}
+	if repairs != 1 {
+		t.Errorf("logged route repairs = %d, want 1", repairs)
+	}
+}
+
+// TestHealthCheck_StillRebuildsWhenTheRouteWasFine proves the repair path does
+// not swallow the silence detector: a tunnel silent for some other reason has
+// nothing to re-pin, so the rebuild still runs.
+func TestHealthCheck_StillRebuildsWhenTheRouteWasFine(t *testing.T) {
+	svc, wgMgr, _ := connectedRouteGuardService(t)
+
+	wgMgr.mu.Lock()
+	startsAfterConnect := wgMgr.startCount
+	wgMgr.mu.Unlock()
+
+	goSilent(wgMgr)
+	svc.runHealthCheck(context.Background())
+
+	wgMgr.mu.Lock()
+	restarts := wgMgr.startCount - startsAfterConnect
+	wgMgr.mu.Unlock()
+	if restarts != 1 {
+		t.Errorf("wireguard restarts = %d, want 1 — nothing was repaired, so the tunnel is still silent", restarts)
+	}
+}
+
+// TestHealthCheck_EndlessRouteRepairsStopDeferringTheRebuild proves a route
+// that never settles cannot suppress recovery forever. Deferring the rebuild is
+// worth it while a repair is plausibly about to work; a route being re-pinned
+// every tick is its own fault, and the session still needs rescuing.
+func TestHealthCheck_EndlessRouteRepairsStopDeferringTheRebuild(t *testing.T) {
+	svc, wgMgr, _ := connectedRouteGuardService(t)
+
+	wgMgr.mu.Lock()
+	startsAfterConnect := wgMgr.startCount
+	wgMgr.routeGuardRepaired = true
+	wgMgr.mu.Unlock()
+
+	goSilent(wgMgr)
+	for range maxEndpointRouteRepairDeferrals + 1 {
+		svc.runHealthCheck(context.Background())
+	}
+
+	wgMgr.mu.Lock()
+	restarts := wgMgr.startCount - startsAfterConnect
+	wgMgr.mu.Unlock()
+	if restarts != 1 {
+		t.Errorf("wireguard restarts = %d, want 1 — the rebuild runs once the repairs stop looking like progress", restarts)
+	}
+}
+
+// TestHealthCheck_RouteGuardErrorDoesNotDropTheSession proves a guard that
+// cannot read the routing table is reported and moved past. Failing to verify a
+// route is not a reason to tear down a working tunnel.
+func TestHealthCheck_RouteGuardErrorDoesNotDropTheSession(t *testing.T) {
+	svc, wgMgr, _ := connectedRouteGuardService(t)
+
+	wgMgr.mu.Lock()
+	wgMgr.routeGuardErr = errors.New("read default routes: access denied")
+	wgMgr.mu.Unlock()
+
+	svc.runHealthCheck(context.Background())
+
+	if st := svc.Status(context.Background()).State; st != state.StateConnected {
+		t.Fatalf("state = %q, want CONNECTED — a guard error is not a dead tunnel", st)
+	}
+	var warned bool
+	for _, entry := range svc.Logs(0) {
+		if strings.Contains(entry.Msg, "could not verify the tunnel's endpoint routes") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Error("expected the guard error to be logged")
+	}
+}

--- a/daemon/internal/api/service.go
+++ b/daemon/internal/api/service.go
@@ -158,6 +158,11 @@ type Service struct {
 	// a correction. Guarded by recoveryMu.
 	dnsGuardNextAt time.Time
 
+	// endpointRouteRepairs counts consecutive health checks that had to re-pin
+	// the tunnel's endpoint routes, so a route that never settles cannot hold
+	// off recovery forever. Guarded by recoveryMu.
+	endpointRouteRepairs int
+
 	// probeResolver resolves over the live tunnel to prove it still carries
 	// traffic. Defaults to probeResolverOverUDP; tests stub it, and a nil value
 	// disables the check.
@@ -179,6 +184,22 @@ type wgPreflightChecker interface {
 
 type wgActiveInterfaceReporter interface {
 	ActiveInterfaceName(ctx context.Context, profile state.WireGuardProfile) (string, error)
+}
+
+// wgTunnelLUIDReporter reports the Windows interface LUID of the live tunnel
+// device, which identifies the adapter exactly where its name does not.
+// Optional: a manager that does not implement it leaves the kill switch to
+// resolve the name itself.
+type wgTunnelLUIDReporter interface {
+	ActiveTunnelLUID(ctx context.Context, profile state.WireGuardProfile) (uint64, error)
+}
+
+// wgRouteGuard re-pins the tunnel's endpoint bypass routes when the host has
+// moved or dropped the default route they hang off, reporting whether it
+// corrected anything. Optional: a manager that does not implement it leaves the
+// routes as bring-up installed them.
+type wgRouteGuard interface {
+	EnsureEndpointRoutes(ctx context.Context, profile state.WireGuardProfile) (bool, error)
 }
 
 // wgDNSGuard re-asserts the tunnel's resolvers when the host has stopped
@@ -491,21 +512,45 @@ func (s *Service) bringUpAfterKillSwitch(ctx context.Context, profile state.Prof
 	s.logs.Add(state.LogInfo, state.SourceDaemon, fmt.Sprintf("%s tunnel established with wireguard handshake (%dms)", kind, time.Since(stepStart).Milliseconds()))
 
 	stepStart = time.Now()
-	tunnelInterface := s.resolveWireGuardInterfaceName(ctx, wireGuardProfile)
-	updateCh := make(chan error, 1)
-	go func() {
-		updateCh <- s.killSwitch.Update(ctx, tunnelInterface)
-	}()
-
-	if updateErr := <-updateCh; updateErr != nil {
-		s.logs.Add(state.LogWarn, state.SourceDaemon, fmt.Sprintf("kill switch tunnel update failed: %v", updateErr))
+	tunnel := s.resolveTunnelRef(ctx, wireGuardProfile)
+	// The permit scoped to this tunnel is what lets application traffic out
+	// through the lock, so a session without it is connected and unusable —
+	// worth failing and rebuilding rather than reporting as healthy.
+	if err := s.killSwitch.Update(ctx, tunnel); err != nil {
+		s.tearDownFailedBringUp(wireGuardProfile)
+		s.setError(fmt.Sprintf("kill switch tunnel update failed: %v", err))
+		return err
 	}
-	s.logs.Add(state.LogInfo, state.SourceDaemon, fmt.Sprintf("kill switch updated (%dms)", time.Since(stepStart).Milliseconds()))
+	// The LUID says which adapter the permit actually names; without it a permit
+	// left on a destroyed adapter is indistinguishable in the log from a good one.
+	s.logs.Add(state.LogInfo, state.SourceDaemon, fmt.Sprintf(
+		"kill switch updated (%dms), permitting %s (LUID %d)", time.Since(stepStart).Milliseconds(), tunnel.Name, tunnel.WindowsLUID))
 
 	s.setCurrentProfile(profile)
 	s.setSessionOpts(opts)
 	s.machine.Set(state.StateConnected, "tunnel active")
 	return nil
+}
+
+// tearDownFailedBringUp stops the tunnel a bring-up had running before it
+// failed, so the next Connect is not refused by a session nobody owns —
+// ensureNoRunningWireGuard would otherwise make the user disconnect by hand
+// first. The kill switch stays armed: a failed connect is fail-closed.
+func (s *Service) tearDownFailedBringUp(wireGuardProfile state.WireGuardProfile) {
+	// Not the caller's context: it may already be cancelled, and this cleanup
+	// still has to run.
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+
+	if err := s.wg.Stop(cleanupCtx, wireGuardProfile); err != nil {
+		s.logs.Add(state.LogWarn, state.SourceDaemon, fmt.Sprintf("cleanup after failed bring-up: wireguard stop warning: %v", err))
+	}
+	if active := s.activeTransport(); active != nil {
+		if err := active.Stop(cleanupCtx); err != nil {
+			s.logs.Add(state.LogWarn, state.SourceDaemon, fmt.Sprintf("cleanup after failed bring-up: transport stop warning: %v", err))
+		}
+	}
+	s.setActiveTransportKind("")
 }
 
 // rebindWireGuardEndpoint checks whether mgr bound a different local port
@@ -1729,7 +1774,14 @@ func (s *Service) runHealthCheck(ctx context.Context) {
 		s.setError(fmt.Sprintf("health check failed: wireguard tunnel is down (%s)", wgStatus.Detail))
 		return
 	}
-	if s.wireGuardHandshakeStale(wgStatus) {
+	// Checked before the silence detector because a lost bypass route is one of
+	// the things that silences a tunnel, and re-pinning it is far cheaper than
+	// the rebuild below. A repair earns the session this tick to handshake on
+	// the restored path; a route that needed no repair reports nothing, so a
+	// tunnel silent for another reason still reaches the rebuild.
+	routeRepaired := s.ensureEndpointRoutes(ctx, profile)
+
+	if !routeRepaired && s.wireGuardHandshakeStale(wgStatus) {
 		age := time.Since(time.Unix(wgStatus.LastHandshakeUnix, 0)).Round(time.Second)
 		s.logs.Add(state.LogWarn, state.SourceDaemon, fmt.Sprintf("wireguard tunnel is silent (no handshake for %s); rebuilding session", age))
 		s.attemptSessionRebuild(ctx, profile, fmt.Sprintf("wireguard tunnel is silent (no handshake for %s)", age))
@@ -1738,6 +1790,12 @@ func (s *Service) runHealthCheck(ctx context.Context) {
 
 	if !s.killSwitch.Active() {
 		s.setError("health check failed: kill switch was cleared unexpectedly")
+		return
+	}
+
+	// A route that was just re-pinned has not had a round trip on it yet, so
+	// probing now would judge the session on the path it no longer uses.
+	if routeRepaired {
 		return
 	}
 
@@ -2103,6 +2161,31 @@ func (s *Service) recoverActiveTransport(ctx context.Context, profile state.Prof
 	default:
 		return fmt.Errorf("unknown active transport kind: %q", activeKind)
 	}
+}
+
+// resolveTunnelRef names the live tunnel for the kill switch. The LUID matters
+// most: it points at the device the manager actually created, where a name has
+// to be resolved back through the OS and can land on an adapter of the same name
+// that a rebuild is still tearing down.
+func (s *Service) resolveTunnelRef(ctx context.Context, profile state.WireGuardProfile) platform.TunnelRef {
+	return platform.TunnelRef{
+		Name:        s.resolveWireGuardInterfaceName(ctx, profile),
+		WindowsLUID: s.resolveTunnelLUID(ctx, profile),
+	}
+}
+
+func (s *Service) resolveTunnelLUID(ctx context.Context, profile state.WireGuardProfile) uint64 {
+	reporter, ok := s.wg.(wgTunnelLUIDReporter)
+	if !ok {
+		return 0
+	}
+
+	luid, err := reporter.ActiveTunnelLUID(ctx, profile)
+	if err != nil {
+		s.logs.Add(state.LogWarn, state.SourceDaemon, fmt.Sprintf("wireguard tunnel LUID lookup failed; the kill switch will resolve the interface by name: %v", err))
+		return 0
+	}
+	return luid
 }
 
 func (s *Service) resolveWireGuardInterfaceName(ctx context.Context, profile state.WireGuardProfile) string {

--- a/daemon/internal/api/service_test.go
+++ b/daemon/internal/api/service_test.go
@@ -392,6 +392,18 @@ type fakeWGManager struct {
 	dnsGuardCorrected bool
 	dnsGuardErr       error
 	dnsGuardCalls     int
+
+	// Endpoint route guard modeling, the same shape as the DNS guard: the method
+	// below is what makes fakeWGManager satisfy wgRouteGuard, and the defaults
+	// report bypass routes still pointing where bring-up left them.
+	routeGuardRepaired bool
+	routeGuardErr      error
+	routeGuardCalls    int
+
+	// tunnelLUID is the adapter the kill switch should be scoped to; luidErr
+	// models a manager that cannot report one.
+	tunnelLUID uint64
+	luidErr    error
 }
 
 // EnsureDNS models the host's interface DNS being checked, and corrected when
@@ -401,6 +413,24 @@ func (f *fakeWGManager) EnsureDNS(_ context.Context, _ state.WireGuardProfile) (
 	defer f.mu.Unlock()
 	f.dnsGuardCalls++
 	return f.dnsGuardCorrected, f.dnsGuardErr
+}
+
+// EnsureEndpointRoutes models the tunnel's bypass routes being checked, and
+// re-pinned when the host's default route has moved or dropped them.
+func (f *fakeWGManager) EnsureEndpointRoutes(_ context.Context, _ state.WireGuardProfile) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.routeGuardCalls++
+	return f.routeGuardRepaired, f.routeGuardErr
+}
+
+func (f *fakeWGManager) ActiveTunnelLUID(_ context.Context, _ state.WireGuardProfile) (uint64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.luidErr != nil {
+		return 0, f.luidErr
+	}
+	return f.tunnelLUID, nil
 }
 
 func (f *fakeWGManager) Start(_ context.Context, profile state.WireGuardProfile) error {
@@ -502,7 +532,7 @@ type fakeKillSwitch struct {
 	enableEndpoints []string
 	enableAllowLAN  bool
 	enableLocked    bool
-	updateInterface string
+	updateTunnel    platform.TunnelRef
 	enableCount     int
 	updateCount     int
 	clearCount      int
@@ -525,11 +555,11 @@ func (f *fakeKillSwitch) Enable(_ context.Context, endpoints []string, allowLAN 
 	return nil
 }
 
-func (f *fakeKillSwitch) Update(_ context.Context, iface string) error {
+func (f *fakeKillSwitch) Update(_ context.Context, tunnel platform.TunnelRef) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.updateCount++
-	f.updateInterface = iface
+	f.updateTunnel = tunnel
 	if f.updateErr != nil {
 		return f.updateErr
 	}
@@ -691,8 +721,8 @@ func TestConnect_UpdateCalledAfterWGSuccess(t *testing.T) {
 	if ks.updateCount != 1 {
 		t.Errorf("expected update called once, got %d", ks.updateCount)
 	}
-	if ks.updateInterface != profile.WireGuard.TunnelName {
-		t.Errorf("expected update interface %q, got %q", profile.WireGuard.TunnelName, ks.updateInterface)
+	if ks.updateTunnel.Name != profile.WireGuard.TunnelName {
+		t.Errorf("expected update interface %q, got %q", profile.WireGuard.TunnelName, ks.updateTunnel.Name)
 	}
 }
 
@@ -714,8 +744,8 @@ func TestConnect_UsesReportedWireGuardInterfaceForKillSwitch(t *testing.T) {
 	if ks.updateCount != 1 {
 		t.Errorf("expected update called once, got %d", ks.updateCount)
 	}
-	if ks.updateInterface != wgMgr.interfaceName {
-		t.Errorf("expected update interface %q, got %q", wgMgr.interfaceName, ks.updateInterface)
+	if ks.updateTunnel.Name != wgMgr.interfaceName {
+		t.Errorf("expected update interface %q, got %q", wgMgr.interfaceName, ks.updateTunnel.Name)
 	}
 }
 
@@ -742,6 +772,65 @@ func TestConnect_WGFailure_KillSwitchStaysActive(t *testing.T) {
 	}
 	if !ks.active {
 		t.Error("expected kill switch to remain active after connect failure (fail-closed)")
+	}
+}
+
+// TestConnect_KillSwitchIsScopedToTheReportedTunnelLUID proves the permit that
+// lets application traffic through the lock is scoped to the device the manager
+// created, not to a name resolved back through the OS. A rebuild recreates the
+// adapter under the same name a second after destroying it, and a name lookup in
+// that window can still return the dead one — leaving the permit on an interface
+// that no longer exists and every application socket blocked.
+func TestConnect_KillSwitchIsScopedToTheReportedTunnelLUID(t *testing.T) {
+	profile := testProfile()
+	wgMgr := &fakeWGManager{interfaceName: "PangeaVPN Tunnel", tunnelLUID: 1688849860263936}
+	ks := &fakeKillSwitch{}
+	svc := newTestService(t, &fakeCloakManager{}, &fakeNaiveManager{}, wgMgr, ks, profile)
+
+	if err := svc.Connect(context.Background(), profile.ID, ConnectOptions{}); err != nil {
+		t.Fatalf("connect failed: %v", err)
+	}
+
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+	if ks.updateTunnel.WindowsLUID != wgMgr.tunnelLUID {
+		t.Errorf("kill switch tunnel LUID = %d, want %d", ks.updateTunnel.WindowsLUID, wgMgr.tunnelLUID)
+	}
+	if ks.updateTunnel.Name != wgMgr.interfaceName {
+		t.Errorf("kill switch tunnel name = %q, want %q", ks.updateTunnel.Name, wgMgr.interfaceName)
+	}
+}
+
+// TestConnect_KillSwitchUpdateFailureFailsTheConnect proves a session whose
+// permit never landed is not reported as connected. Without it the lock blocks
+// every application socket while WireGuard — permitted separately by endpoint
+// IP — goes on handshaking, so the tunnel looks healthy from every angle the
+// daemon checks while nothing on the machine works.
+func TestConnect_KillSwitchUpdateFailureFailsTheConnect(t *testing.T) {
+	profile := testProfile()
+	wgMgr := &fakeWGManager{}
+	ks := &fakeKillSwitch{updateErr: errors.New("permit tunnel interface: no such interface")}
+	svc := newTestService(t, &fakeCloakManager{}, &fakeNaiveManager{}, wgMgr, ks, profile)
+
+	if err := svc.Connect(context.Background(), profile.ID, ConnectOptions{}); err == nil {
+		t.Fatal("expected connect to fail when the tunnel permit could not be added")
+	}
+	if st := svc.Status(context.Background()).State; st != state.StateError {
+		t.Errorf("state = %q, want ERROR", st)
+	}
+	if !ks.Active() {
+		t.Error("expected the kill switch to stay armed — a failed connect must leave the device fail-closed")
+	}
+
+	// Left running, the tunnel belongs to nobody: no profile was ever recorded
+	// for the health loop to recover, and the next Connect is refused outright
+	// by ensureNoRunningWireGuard.
+	status, err := wgMgr.Status(context.Background(), profile.WireGuard)
+	if err != nil {
+		t.Fatalf("wireguard status failed: %v", err)
+	}
+	if status.Running {
+		t.Error("expected the tunnel to be torn down after the permit could not be added")
 	}
 }
 

--- a/daemon/internal/platform/killswitch.go
+++ b/daemon/internal/platform/killswitch.go
@@ -28,7 +28,7 @@ type KillSwitch interface {
 
 	// Update adds an allow rule for the active tunnel interface so that
 	// VPN-routed traffic can egress.
-	Update(ctx context.Context, tunnelInterface string) error
+	Update(ctx context.Context, tunnel TunnelRef) error
 
 	// Clear removes all kill-switch rules and restores the previous
 	// network policy. Returns an error if restoration fails.
@@ -36,6 +36,16 @@ type KillSwitch interface {
 
 	// Active reports whether the kill switch is currently engaged.
 	Active() bool
+}
+
+// TunnelRef identifies the tunnel adapter a permit is scoped to: Name is what
+// pf and nftables match on, WindowsLUID is the WFP condition. The LUID is
+// carried rather than resolved from Name because a rebuild recreates the
+// adapter under the same name a second after destroying it, and a lookup in
+// that window can still return the one on its way out.
+type TunnelRef struct {
+	Name        string
+	WindowsLUID uint64
 }
 
 // LANAllowPrefixes are the IPv4 ranges the kill switch permits when
@@ -101,7 +111,7 @@ func NewKillSwitch() KillSwitch {
 type noopKillSwitch struct{}
 
 func (n *noopKillSwitch) Enable(_ context.Context, _ []string, _ bool, _ bool) error { return nil }
-func (n *noopKillSwitch) Update(_ context.Context, _ string) error                   { return nil }
+func (n *noopKillSwitch) Update(_ context.Context, _ TunnelRef) error                { return nil }
 func (n *noopKillSwitch) Clear(_ context.Context) error                              { return nil }
 func (n *noopKillSwitch) Active() bool                                               { return false }
 

--- a/daemon/internal/platform/killswitch_darwin.go
+++ b/daemon/internal/platform/killswitch_darwin.go
@@ -71,7 +71,7 @@ func (ks *darwinKillSwitch) Enable(ctx context.Context, endpointHosts []string, 
 	return nil
 }
 
-func (ks *darwinKillSwitch) Update(ctx context.Context, tunnelInterface string) error {
+func (ks *darwinKillSwitch) Update(ctx context.Context, tunnel TunnelRef) error {
 	ks.mu.Lock()
 	defer ks.mu.Unlock()
 
@@ -79,7 +79,7 @@ func (ks *darwinKillSwitch) Update(ctx context.Context, tunnelInterface string) 
 		return fmt.Errorf("kill switch not active")
 	}
 
-	tunnelInterface = strings.TrimSpace(tunnelInterface)
+	tunnelInterface := strings.TrimSpace(tunnel.Name)
 	if tunnelInterface == "" {
 		return fmt.Errorf("empty tunnel interface name")
 	}

--- a/daemon/internal/platform/killswitch_linux.go
+++ b/daemon/internal/platform/killswitch_linux.go
@@ -85,7 +85,7 @@ func (ks *linuxKillSwitch) Enable(ctx context.Context, endpointHosts []string, a
 	return nil
 }
 
-func (ks *linuxKillSwitch) Update(ctx context.Context, tunnelInterface string) error {
+func (ks *linuxKillSwitch) Update(ctx context.Context, tunnel TunnelRef) error {
 	ks.mu.Lock()
 	defer ks.mu.Unlock()
 
@@ -93,7 +93,7 @@ func (ks *linuxKillSwitch) Update(ctx context.Context, tunnelInterface string) e
 		return fmt.Errorf("kill switch not active")
 	}
 
-	tunnelInterface = strings.TrimSpace(tunnelInterface)
+	tunnelInterface := strings.TrimSpace(tunnel.Name)
 	if tunnelInterface == "" {
 		return fmt.Errorf("empty tunnel interface name")
 	}

--- a/daemon/internal/platform/killswitch_test.go
+++ b/daemon/internal/platform/killswitch_test.go
@@ -160,7 +160,7 @@ func TestNoopKillSwitch(t *testing.T) {
 	if err := ks.Enable(context.Background(), []string{"203.0.113.4"}, false, false); err != nil {
 		t.Errorf("enable should not fail: %v", err)
 	}
-	if err := ks.Update(context.Background(), "wg0"); err != nil {
+	if err := ks.Update(context.Background(), TunnelRef{Name: "wg0"}); err != nil {
 		t.Errorf("update should not fail: %v", err)
 	}
 	if err := ks.Clear(context.Background()); err != nil {

--- a/daemon/internal/platform/killswitch_windows.go
+++ b/daemon/internal/platform/killswitch_windows.go
@@ -248,7 +248,7 @@ func (ks *windowsKillSwitch) Enable(ctx context.Context, endpointHosts []string,
 	return nil
 }
 
-func (ks *windowsKillSwitch) Update(ctx context.Context, tunnelInterface string) error {
+func (ks *windowsKillSwitch) Update(ctx context.Context, tunnel TunnelRef) error {
 	ks.mu.Lock()
 	defer ks.mu.Unlock()
 
@@ -256,19 +256,9 @@ func (ks *windowsKillSwitch) Update(ctx context.Context, tunnelInterface string)
 		return fmt.Errorf("kill switch not active")
 	}
 
-	tunnelInterface = strings.TrimSpace(tunnelInterface)
-	if tunnelInterface == "" {
-		return fmt.Errorf("empty tunnel interface name")
-	}
-
-	// Resolve the tunnel adapter's LUID so we can permit traffic through it.
-	iface, err := net.InterfaceByName(tunnelInterface)
+	luid, err := resolveTunnelLUID(tunnel)
 	if err != nil {
-		return fmt.Errorf("kill switch update: resolve interface %q: %w", tunnelInterface, err)
-	}
-	luid, err := winipcfg.LUIDFromIndex(uint32(iface.Index))
-	if err != nil {
-		return fmt.Errorf("kill switch update: LUID for %q: %w", tunnelInterface, err)
+		return fmt.Errorf("kill switch update: %w", err)
 	}
 
 	// Remove previous tunnel permit if we're being called again (e.g. reconnect).
@@ -281,17 +271,44 @@ func (ks *windowsKillSwitch) Update(ctx context.Context, tunnelInterface string)
 	// adapter. Without a permit scoped to the tunnel interface LUID, the
 	// block-all-outbound rule drops every packet at socket level — explaining
 	// "general failure" on ping even though the WireGuard handshake succeeds.
-	filterId, err := ks.engine.addPermitTunnelInterface(uint64(luid))
+	filterId, err := ks.engine.addPermitTunnelInterface(luid)
 	if err != nil {
 		return fmt.Errorf("kill switch update: permit tunnel interface: %w", err)
 	}
 	ks.tunnelFilterId = filterId
 
 	st, _ := loadKillSwitchState()
-	st.TunnelInterface = tunnelInterface
+	st.TunnelInterface = strings.TrimSpace(tunnel.Name)
 	_ = saveKillSwitchState(st)
 
 	return nil
+}
+
+// resolveTunnelLUID prefers the LUID the caller already holds for the live
+// device, falling back to a name lookup only when it has none.
+//
+// The fallback is what this exists to avoid: after a rebuild
+// GetAdaptersAddresses can still return the dying adapter's index, and a permit
+// naming an interface that no longer exists leaves block-all-outbound dropping
+// every application socket while WireGuard goes on handshaking.
+func resolveTunnelLUID(tunnel TunnelRef) (uint64, error) {
+	if tunnel.WindowsLUID != 0 {
+		return tunnel.WindowsLUID, nil
+	}
+
+	name := strings.TrimSpace(tunnel.Name)
+	if name == "" {
+		return 0, fmt.Errorf("tunnel has neither a LUID nor an interface name")
+	}
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return 0, fmt.Errorf("resolve interface %q: %w", name, err)
+	}
+	luid, err := winipcfg.LUIDFromIndex(uint32(iface.Index))
+	if err != nil {
+		return 0, fmt.Errorf("LUID for %q: %w", name, err)
+	}
+	return uint64(luid), nil
 }
 
 func (ks *windowsKillSwitch) Clear(ctx context.Context) error {

--- a/daemon/internal/wg/darwin_linux_shared.go
+++ b/daemon/internal/wg/darwin_linux_shared.go
@@ -228,6 +228,20 @@ func (m *wireGuardGoManager) removeSession(tunnelKey string) {
 	delete(m.sessions, tunnelKey)
 }
 
+// takeSession claims a session for teardown, dropping it from the map in the
+// same step. Guards that repair a live session hold the same lock, so a repair
+// either finishes before teardown claims the session or finds nothing left —
+// it can never re-install networking that teardown has just removed.
+func (m *wireGuardGoManager) takeSession(tunnelKey string) (*tunnelSession, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s, ok := m.sessions[tunnelKey]
+	if ok {
+		delete(m.sessions, tunnelKey)
+	}
+	return s, ok
+}
+
 func (m *wireGuardGoManager) hasActiveDevice(tunnelKey string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -264,6 +278,50 @@ func (m *wireGuardGoManager) ActiveInterfaceName(_ context.Context, profile stat
 	}
 
 	return interfaceName, nil
+}
+
+// ActiveTunnelLUID reports the Windows interface LUID of the live tunnel device.
+// It identifies the adapter exactly, where a name does not: a rebuild destroys
+// and recreates the adapter under the same name a second apart, so a name
+// resolved through the OS can still land on the one that is going away. Zero on
+// other platforms.
+func (m *wireGuardGoManager) ActiveTunnelLUID(_ context.Context, profile state.WireGuardProfile) (uint64, error) {
+	if strings.TrimSpace(profile.TunnelName) == "" {
+		return 0, errors.New("wireguard tunnelName is required")
+	}
+
+	session, ok := m.session(sanitizeTunnelName(profile.TunnelName))
+	if !ok || session == nil {
+		return 0, fmt.Errorf("wireguard tunnel %s is not running", profile.TunnelName)
+	}
+	return session.windowsLUID, nil
+}
+
+// EnsureEndpointRoutes re-pins the session's endpoint bypass routes to the
+// host's current default route, reporting whether it had to repair anything.
+// The lock is held throughout so the repair cannot race a teardown claiming the
+// same session.
+func (m *wireGuardGoManager) EnsureEndpointRoutes(_ context.Context, profile state.WireGuardProfile) (bool, error) {
+	if strings.TrimSpace(profile.TunnelName) == "" {
+		return false, nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	session, ok := m.sessions[sanitizeTunnelName(profile.TunnelName)]
+	if !ok || session == nil {
+		return false, nil
+	}
+
+	// Read directly rather than through ActiveLUIDs, which takes the lock this
+	// already holds. Every tunnel is off limits as a next hop, not just this one.
+	excludeLUIDs := make(map[uint64]struct{}, len(m.sessions))
+	for _, s := range m.sessions {
+		if s != nil && s.windowsLUID != 0 {
+			excludeLUIDs[s.windowsLUID] = struct{}{}
+		}
+	}
+	return ensureSessionEndpointRoutes(session, excludeLUIDs)
 }
 
 // ---------------------------------------------------------------------------

--- a/daemon/internal/wg/netconf_darwin.go
+++ b/daemon/internal/wg/netconf_darwin.go
@@ -291,3 +291,10 @@ func restoreDarwinDNSServers(overrides []darwinDNSOverride) error {
 func ensureSessionDNS(_ *tunnelSession, _ []string) (bool, error) {
 	return false, nil
 }
+
+// ensureSessionEndpointRoutes is Windows-only: there the bypass route is pinned
+// to a gateway that the OS can drop or move mid-session. The macOS route stays
+// as installed until teardown removes it.
+func ensureSessionEndpointRoutes(_ *tunnelSession, _ map[uint64]struct{}) (bool, error) {
+	return false, nil
+}

--- a/daemon/internal/wg/netconf_linux.go
+++ b/daemon/internal/wg/netconf_linux.go
@@ -514,3 +514,10 @@ func restoreLinuxDNSServers(override *linuxDNSOverride) error {
 func ensureSessionDNS(_ *tunnelSession, _ []string) (bool, error) {
 	return false, nil
 }
+
+// ensureSessionEndpointRoutes is Windows-only: there the bypass route is pinned
+// to a gateway that the OS can drop or move mid-session. The Linux route stays
+// as installed until teardown removes it.
+func ensureSessionEndpointRoutes(_ *tunnelSession, _ map[uint64]struct{}) (bool, error) {
+	return false, nil
+}

--- a/daemon/internal/wg/netconf_windows.go
+++ b/daemon/internal/wg/netconf_windows.go
@@ -63,12 +63,7 @@ func configureWindowsInterface(luidValue uint64, addresses []string, allowedIPs 
 
 	routes4 := make([]*winipcfg.RouteData, 0, len(allowed4))
 	routes6 := make([]*winipcfg.RouteData, 0, len(allowed6))
-	hasDefault4 := false
-	hasDefault6 := false
 	for _, prefix := range allowed4 {
-		if prefix.Bits() <= 1 {
-			hasDefault4 = true
-		}
 		routes4 = append(routes4, &winipcfg.RouteData{
 			Destination: prefix,
 			NextHop:     netip.IPv4Unspecified(),
@@ -76,9 +71,6 @@ func configureWindowsInterface(luidValue uint64, addresses []string, allowedIPs 
 		})
 	}
 	for _, prefix := range allowed6 {
-		if prefix.Bits() <= 1 {
-			hasDefault6 = true
-		}
 		routes6 = append(routes6, &winipcfg.RouteData{
 			Destination: prefix,
 			NextHop:     netip.IPv6Unspecified(),
@@ -99,7 +91,7 @@ func configureWindowsInterface(luidValue uint64, addresses []string, allowedIPs 
 	if err := luid.SetIPAddressesForFamily(windowsFamilyV6, addresses6); err != nil {
 		errs = append(errs, fmt.Errorf("set IPv6 addresses: %w", err))
 	}
-	if err := configureWindowsIPInterface(luid, mtu, hasDefault4, hasDefault6); err != nil {
+	if err := configureWindowsIPInterface(luid, mtu); err != nil {
 		errs = append(errs, err)
 	}
 	if err := applyWindowsDNSServers(luid, dnsServers); err != nil {
@@ -139,20 +131,20 @@ func clearWindowsInterfaceConfig(luidValue uint64) error {
 	return errors.Join(errs...)
 }
 
-func configureWindowsIPInterface(luid winipcfg.LUID, mtu int, hasDefault4 bool, hasDefault6 bool) error {
+func configureWindowsIPInterface(luid winipcfg.LUID, mtu int) error {
 	var errs []error
 
-	if err := tuneWindowsIPInterface(luid, windowsFamilyV4, mtu, hasDefault4); err != nil {
+	if err := tuneWindowsIPInterface(luid, windowsFamilyV4, mtu); err != nil {
 		errs = append(errs, fmt.Errorf("configure IPv4 interface settings: %w", err))
 	}
-	if err := tuneWindowsIPInterface(luid, windowsFamilyV6, mtu, hasDefault6); err != nil {
+	if err := tuneWindowsIPInterface(luid, windowsFamilyV6, mtu); err != nil {
 		errs = append(errs, fmt.Errorf("configure IPv6 interface settings: %w", err))
 	}
 
 	return errors.Join(errs...)
 }
 
-func tuneWindowsIPInterface(luid winipcfg.LUID, family winipcfg.AddressFamily, mtu int, forceMetric bool) error {
+func tuneWindowsIPInterface(luid winipcfg.LUID, family winipcfg.AddressFamily, mtu int) error {
 	row, err := luid.IPInterface(family)
 	if err != nil {
 		if errors.Is(err, windows.ERROR_NOT_FOUND) {
@@ -169,10 +161,11 @@ func tuneWindowsIPInterface(luid winipcfg.LUID, family winipcfg.AddressFamily, m
 	if mtu > 0 && mtu <= math.MaxUint32 {
 		row.NLMTU = uint32(mtu)
 	}
-	if forceMetric {
-		row.UseAutomaticMetric = false
-		row.Metric = 0
-	}
+	// Windows orders route selection and DNS preference by interface metric, so
+	// an automatic metric leaves the tunnel merely tied with other virtual
+	// adapters instead of decisively ahead.
+	row.UseAutomaticMetric = false
+	row.Metric = 0
 	return row.Set()
 }
 
@@ -257,13 +250,13 @@ func windowsDNSMatches(current []netip.Addr, want []netip.Addr) bool {
 	return slices.Equal(got, want)
 }
 
-func addWindowsEndpointRoutes(ctx context.Context, tunnelLUID uint64, endpointHosts []string) ([]windowsRouteSpec, error) {
+func addWindowsEndpointRoutes(ctx context.Context, excludeLUIDs map[uint64]struct{}, endpointHosts []string) ([]windowsRouteSpec, error) {
 	routes := resolveEndpointRoutes(ctx, endpointHosts)
 	if len(routes) == 0 {
 		return nil, nil
 	}
 
-	defaultRoutes, err := windowsDefaultRoutesByFamily(tunnelLUID)
+	defaultRoutes, err := windowsDefaultRoutesByFamily(excludeLUIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -285,38 +278,142 @@ func addWindowsEndpointRoutes(ctx context.Context, tunnelLUID uint64, endpointHo
 			bits = 32
 		}
 
-		destination := netip.PrefixFrom(addr, bits).Masked()
-		routeData := &winipcfg.RouteData{
-			Destination: destination,
-			NextHop:     defaultRoute.nextHop,
-			Metric:      0,
+		spec := windowsRouteSpec{
+			interfaceLUID: uint64(defaultRoute.interfaceLUID),
+			destination:   netip.PrefixFrom(addr, bits).Masked().String(),
+			nextHop:       defaultRoute.nextHop.String(),
 		}
-		if err := defaultRoute.interfaceLUID.AddRoutes([]*winipcfg.RouteData{routeData}); err != nil {
-			if errors.Is(err, windows.ERROR_OBJECT_ALREADY_EXISTS) {
-				continue
-			}
-			errs = append(errs, fmt.Errorf("add endpoint route %s via %s: %w", destination.String(), defaultRoute.nextHop.String(), err))
+		created, err := addWindowsRoute(spec)
+		if err != nil {
+			errs = append(errs, err)
 			continue
 		}
-
-		added = append(added, windowsRouteSpec{
-			interfaceLUID: uint64(defaultRoute.interfaceLUID),
-			destination:   destination.String(),
-			nextHop:       defaultRoute.nextHop.String(),
-		})
+		// A route that was already there is not ours to remove at teardown.
+		if created {
+			added = append(added, spec)
+		}
 	}
 
 	return added, errors.Join(errs...)
 }
 
+// ensureSessionEndpointRoutes re-pins the endpoint bypass routes to the host's
+// current default route, reporting whether it had to repair anything.
+//
+// Windows drops an interface's routes on a media-sense flap, and a roam or DHCP
+// renewal moves the gateway out from under them. Either way the node's address
+// falls back to matching the tunnel's own AllowedIPs and WireGuard ends up
+// routed into the tunnel it is trying to establish.
+func ensureSessionEndpointRoutes(session *tunnelSession, excludeLUIDs map[uint64]struct{}) (bool, error) {
+	if session == nil || session.windowsLUID == 0 || len(session.windowsRoutes) == 0 {
+		return false, nil
+	}
+
+	defaultRoutes, err := windowsDefaultRoutesByFamily(excludeLUIDs)
+	if err != nil {
+		return false, fmt.Errorf("read default routes: %w", err)
+	}
+
+	repaired := false
+	var errs []error
+	for i := range session.windowsRoutes {
+		current := session.windowsRoutes[i]
+		want, ok := plannedEndpointRoute(current, defaultRoutes)
+		if !ok {
+			continue
+		}
+		if want == current && windowsRouteIsPresent(current) {
+			continue
+		}
+
+		// New route in before the old one goes out. When the gateway has merely
+		// moved the old route is still installed and still the session's only way
+		// out, so removing it first would mean a failed add leaves the node with
+		// no path at all — the very failure this repairs.
+		created, err := addWindowsRoute(want)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if want == current && !created {
+			// The route was there all along and the lookup simply could not
+			// confirm it. Reporting a repair here would have the health check
+			// deferring to a fix that never happened, every tick.
+			continue
+		}
+		if want != current {
+			if err := removeWindowsEndpointRoutes([]windowsRouteSpec{current}); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		session.windowsRoutes[i] = want
+		repaired = true
+	}
+
+	return repaired, errors.Join(errs...)
+}
+
+// plannedEndpointRoute reports where a recorded bypass route should point given
+// the host's default routes now. ok is false when there is nothing to pin it to
+// — mid-roam, or the link is down — which leaves the recorded spec for a later
+// pass rather than tearing up a route with nowhere to put it.
+func plannedEndpointRoute(spec windowsRouteSpec, defaultRoutes map[string]windowsDefaultRoute) (windowsRouteSpec, bool) {
+	destination, err := netip.ParsePrefix(strings.TrimSpace(spec.destination))
+	if err != nil {
+		return windowsRouteSpec{}, false
+	}
+
+	family := "inet"
+	if !destination.Addr().Is4() {
+		family = "inet6"
+	}
+	defaultRoute, ok := defaultRoutes[family]
+	if !ok {
+		return windowsRouteSpec{}, false
+	}
+
+	return windowsRouteSpec{
+		interfaceLUID: uint64(defaultRoute.interfaceLUID),
+		destination:   spec.destination,
+		nextHop:       defaultRoute.nextHop.String(),
+	}, true
+}
+
+// windowsRouteIsPresent reports whether the route is still in the forwarding
+// table. Anything it cannot confirm counts as absent: re-adding a route that is
+// in fact there is free, while skipping one that is gone costs the session.
+func windowsRouteIsPresent(spec windowsRouteSpec) bool {
+	destination, nextHop, err := parseWindowsRouteSpec(spec)
+	if err != nil {
+		return false
+	}
+	row, err := winipcfg.LUID(spec.interfaceLUID).Route(destination, nextHop)
+	return err == nil && row != nil
+}
+
+// addWindowsRoute installs the route and reports whether it created it. An
+// route that was already there is not an error, but it is not a change either —
+// callers use that to tell a real repair from a no-op.
+func addWindowsRoute(spec windowsRouteSpec) (bool, error) {
+	destination, nextHop, err := parseWindowsRouteSpec(spec)
+	if err != nil {
+		return false, err
+	}
+
+	routeData := &winipcfg.RouteData{Destination: destination, NextHop: nextHop, Metric: 0}
+	if err := winipcfg.LUID(spec.interfaceLUID).AddRoutes([]*winipcfg.RouteData{routeData}); err != nil {
+		if errors.Is(err, windows.ERROR_OBJECT_ALREADY_EXISTS) {
+			return false, nil
+		}
+		return false, fmt.Errorf("add endpoint route %s via %s: %w", destination.String(), nextHop.String(), err)
+	}
+	return true, nil
+}
+
 func removeWindowsEndpointRoutes(routes []windowsRouteSpec) error {
 	var errs []error
 	for _, route := range routes {
-		destination, err := netip.ParsePrefix(strings.TrimSpace(route.destination))
-		if err != nil {
-			continue
-		}
-		nextHop, err := netip.ParseAddr(strings.TrimSpace(route.nextHop))
+		destination, nextHop, err := parseWindowsRouteSpec(route)
 		if err != nil {
 			continue
 		}
@@ -329,11 +426,22 @@ func removeWindowsEndpointRoutes(routes []windowsRouteSpec) error {
 	return errors.Join(errs...)
 }
 
-func windowsDefaultRoutesByFamily(excludeLUID uint64) (map[string]windowsDefaultRoute, error) {
-	out := make(map[string]windowsDefaultRoute, 2)
-	exclude := winipcfg.LUID(excludeLUID)
+func parseWindowsRouteSpec(spec windowsRouteSpec) (netip.Prefix, netip.Addr, error) {
+	destination, err := netip.ParsePrefix(strings.TrimSpace(spec.destination))
+	if err != nil {
+		return netip.Prefix{}, netip.Addr{}, fmt.Errorf("invalid endpoint route destination %q: %w", spec.destination, err)
+	}
+	nextHop, err := netip.ParseAddr(strings.TrimSpace(spec.nextHop))
+	if err != nil {
+		return netip.Prefix{}, netip.Addr{}, fmt.Errorf("invalid endpoint route next hop %q: %w", spec.nextHop, err)
+	}
+	return destination, nextHop, nil
+}
 
-	v4, ok, err := bestWindowsDefaultRoute(windowsFamilyV4, exclude)
+func windowsDefaultRoutesByFamily(excludeLUIDs map[uint64]struct{}) (map[string]windowsDefaultRoute, error) {
+	out := make(map[string]windowsDefaultRoute, 2)
+
+	v4, ok, err := bestWindowsDefaultRoute(windowsFamilyV4, excludeLUIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -341,7 +449,7 @@ func windowsDefaultRoutesByFamily(excludeLUID uint64) (map[string]windowsDefault
 		out["inet"] = v4
 	}
 
-	v6, ok, err := bestWindowsDefaultRoute(windowsFamilyV6, exclude)
+	v6, ok, err := bestWindowsDefaultRoute(windowsFamilyV6, excludeLUIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -352,7 +460,7 @@ func windowsDefaultRoutesByFamily(excludeLUID uint64) (map[string]windowsDefault
 	return out, nil
 }
 
-func bestWindowsDefaultRoute(family winipcfg.AddressFamily, excludeLUID winipcfg.LUID) (windowsDefaultRoute, bool, error) {
+func bestWindowsDefaultRoute(family winipcfg.AddressFamily, excludeLUIDs map[uint64]struct{}) (windowsDefaultRoute, bool, error) {
 	table, err := winipcfg.GetIPForwardTable2(family)
 	if err != nil {
 		return windowsDefaultRoute{}, false, err
@@ -368,12 +476,18 @@ func bestWindowsDefaultRoute(family winipcfg.AddressFamily, excludeLUID winipcfg
 		if !prefix.IsValid() || prefix.Bits() != 0 {
 			continue
 		}
-		if row.InterfaceLUID == excludeLUID || row.Loopback {
+		if _, excluded := excludeLUIDs[uint64(row.InterfaceLUID)]; excluded || row.Loopback {
 			continue
 		}
 
 		nextHop := row.NextHop.Addr()
 		if !nextHop.IsValid() || nextHop.IsLoopback() || nextHop.IsMulticast() {
+			continue
+		}
+		// An on-link default belongs to a tunnel, not a gateway. Pinning the
+		// node's bypass to one would route WireGuard through a tunnel — its own
+		// after a rebuild, or another VPN's — which is the loop this avoids.
+		if nextHop.IsUnspecified() {
 			continue
 		}
 
@@ -387,7 +501,12 @@ func bestWindowsDefaultRoute(family winipcfg.AddressFamily, excludeLUID winipcfg
 			metric += uint64(ipif.Metric)
 		}
 
-		if !bestFound || metric < best.metric {
+		// Ties break on the lower LUID rather than on table order, so repeated
+		// elections agree with each other. An answer that alternated between
+		// two equal-metric gateways would have the route guard re-pinning the
+		// bypass on every health check.
+		if !bestFound || metric < best.metric ||
+			(metric == best.metric && row.InterfaceLUID < best.interfaceLUID) {
 			best = windowsDefaultRoute{
 				interfaceLUID: row.InterfaceLUID,
 				nextHop:       nextHop,

--- a/daemon/internal/wg/netconf_windows_test.go
+++ b/daemon/internal/wg/netconf_windows_test.go
@@ -5,6 +5,8 @@ package wg
 import (
 	"net/netip"
 	"testing"
+
+	"golang.zx2c4.com/wireguard/windows/tunnel/winipcfg"
 )
 
 func TestParseWindowsPrefixes_PreservesInterfaceHostBits(t *testing.T) {
@@ -38,6 +40,95 @@ func TestParseWindowsRoutePrefixes_MasksNetworks(t *testing.T) {
 	}
 	if got, want := v4[0].String(), "10.0.0.0/24"; got != want {
 		t.Fatalf("expected route prefix %q, got %q", want, got)
+	}
+}
+
+func TestPlannedEndpointRoute(t *testing.T) {
+	defaults := func(luid uint64, nextHop string) map[string]windowsDefaultRoute {
+		return map[string]windowsDefaultRoute{
+			"inet": {
+				interfaceLUID: winipcfg.LUID(luid),
+				nextHop:       netip.MustParseAddr(nextHop),
+			},
+		}
+	}
+	spec := windowsRouteSpec{interfaceLUID: 7, destination: "203.0.113.9/32", nextHop: "192.168.1.1"}
+
+	tests := []struct {
+		name     string
+		spec     windowsRouteSpec
+		defaults map[string]windowsDefaultRoute
+		want     windowsRouteSpec
+		ok       bool
+	}{
+		{
+			name:     "unchanged default route plans the same spec",
+			spec:     spec,
+			defaults: defaults(7, "192.168.1.1"),
+			want:     spec,
+			ok:       true,
+		},
+		{
+			// DHCP renewal onto a new gateway, or a roam to another subnet.
+			name:     "new gateway repoints the bypass",
+			spec:     spec,
+			defaults: defaults(7, "10.20.0.1"),
+			want:     windowsRouteSpec{interfaceLUID: 7, destination: "203.0.113.9/32", nextHop: "10.20.0.1"},
+			ok:       true,
+		},
+		{
+			// Wi-Fi to Ethernet, dock/undock, adapter power cycle.
+			name:     "new default interface repoints the bypass",
+			spec:     spec,
+			defaults: defaults(9, "192.168.1.1"),
+			want:     windowsRouteSpec{interfaceLUID: 9, destination: "203.0.113.9/32", nextHop: "192.168.1.1"},
+			ok:       true,
+		},
+		{
+			// Nothing to pin to yet: mid-roam, or the link is down. Leaving the
+			// recorded spec alone lets the next tick fix it once a route exists.
+			name:     "no default route leaves the spec alone",
+			spec:     spec,
+			defaults: map[string]windowsDefaultRoute{},
+			ok:       false,
+		},
+		{
+			name:     "unparseable destination is skipped",
+			spec:     windowsRouteSpec{interfaceLUID: 7, destination: "not-a-prefix", nextHop: "192.168.1.1"},
+			defaults: defaults(7, "192.168.1.1"),
+			ok:       false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := plannedEndpointRoute(tc.spec, tc.defaults)
+			if ok != tc.ok {
+				t.Fatalf("plannedEndpointRoute ok = %t, want %t", ok, tc.ok)
+			}
+			if ok && got != tc.want {
+				t.Errorf("plannedEndpointRoute = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPlannedEndpointRoute_IPv6SpecUsesTheIPv6Default proves the family split
+// keys off the destination rather than assuming IPv4.
+func TestPlannedEndpointRoute_IPv6SpecUsesTheIPv6Default(t *testing.T) {
+	defaults := map[string]windowsDefaultRoute{
+		"inet":  {interfaceLUID: 1, nextHop: netip.MustParseAddr("192.168.1.1")},
+		"inet6": {interfaceLUID: 2, nextHop: netip.MustParseAddr("fe80::1")},
+	}
+	spec := windowsRouteSpec{interfaceLUID: 9, destination: "2001:db8::1/128", nextHop: "fe80::9"}
+
+	got, ok := plannedEndpointRoute(spec, defaults)
+	if !ok {
+		t.Fatal("expected an IPv6 spec to plan against the IPv6 default route")
+	}
+	want := windowsRouteSpec{interfaceLUID: 2, destination: "2001:db8::1/128", nextHop: "fe80::1"}
+	if got != want {
+		t.Errorf("plannedEndpointRoute = %+v, want %+v", got, want)
 	}
 }
 

--- a/daemon/internal/wg/windows.go
+++ b/daemon/internal/wg/windows.go
@@ -91,7 +91,12 @@ func (m *wireGuardGoManager) startWindows(ctx context.Context, profile state.Wir
 		return err
 	}
 
-	endpointRoutes, endpointErr := addWindowsEndpointRoutes(ctx, tunnelLUID, parsed.endpointHosts)
+	// Every tunnel on the box is off limits as a next hop for the bypass, not
+	// just this one: routing WireGuard through any of them is a loop.
+	excludeLUIDs := m.ActiveLUIDs()
+	excludeLUIDs[tunnelLUID] = struct{}{}
+
+	endpointRoutes, endpointErr := addWindowsEndpointRoutes(ctx, excludeLUIDs, parsed.endpointHosts)
 	if endpointErr != nil {
 		m.logs.Add(state.LogWarn, state.SourceWireGuard, fmt.Sprintf("endpoint bypass route setup warning: %v", endpointErr))
 	}
@@ -123,7 +128,7 @@ func (m *wireGuardGoManager) stopWindows(_ context.Context, profile state.WireGu
 	}
 
 	tunnelKey := sanitizeTunnelName(profile.TunnelName)
-	session, hasSession := m.session(tunnelKey)
+	session, hasSession := m.takeSession(tunnelKey)
 	if !hasSession || session == nil {
 		return nil
 	}
@@ -141,7 +146,6 @@ func (m *wireGuardGoManager) stopWindows(_ context.Context, profile state.WireGu
 	}
 
 	closeDevice(session.device)
-	m.removeSession(tunnelKey)
 	m.logs.Add(state.LogInfo, state.SourceWireGuard, fmt.Sprintf("wireguard stopped for %s (%s)", profile.TunnelName, session.interfaceName))
 	return nil
 }


### PR DESCRIPTION
Fixes the two defects in #22: whatever silenced the session, and why the automatic rebuild did not bring connectivity back.

## What silenced the session

Finding 1 in the issue, with the mechanism sharpened. The endpoint bypass route — a `/32` to the node pinned to the physical default gateway — is the only path WireGuard's UDP has out, because everything else the host sends matches the tunnel's own AllowedIPs. It was installed once at bring-up and never revisited.

The issue framed this as "the default route moves". The stronger version needs no user-visible network change at all: **Windows drops an interface's routes on a media-sense flap** — a Wi-Fi re-association, a driver reset, a DHCP rebind. DHCP restores the default route; nothing restores our `/32`. Once it is gone the node's address falls back to matching AllowedIPs, so WireGuard's encrypted UDP is routed *into the TUN device*, comes back as plaintext destined for the node, and is encrypted again. Nothing leaves the machine.

That matches the capture exactly: server reachable throughout, keepalives flowing until the instant of death, and a fresh socket answered in under a second after the rebuild — because `wg.Stop`/`Start` re-adds the `/32` against the current routing table. It also explains "stable for 45+ minutes, then dies" without requiring anything to visibly change.

**Fix:** the health check re-pins these routes every tick against the host's current default route, re-adding them when the OS has dropped them. A repair is given the tick to take effect before the silence detector runs, so the common case becomes a route rewrite (~3s) instead of a three-minute outage plus a full session rebuild.

## Why the rebuild did not restore connectivity

Finding 2, confirmed and sharpened. I compared rebuild against manual reconnect line by line: the **only** state that survives a rebuild but not a reconnect is the WFP dynamic session. Everything else — adapter, routes, DNS, transport — is torn down and rebuilt identically. So if rebuild fails where reconnect succeeds, the stale thing is in WFP by construction.

Two concrete ways the tunnel permit went wrong:

1. **The LUID is always stale, and the name lookup can be too.** A rebuild destroys the Wintun adapter and recreates it under the same name a second later. The GUID keeps the name and network profile, but the LUID is per device instance, so the old permit is dead regardless. `Update` then re-resolved by `net.InterfaceByName` → `LUIDFromIndex`, and `GetAdaptersAddresses` can still return the dying adapter's `ifIndex` inside that window.
2. **The failure was silent and never retried.** A failed `Update` was logged as a warning while the state still went `Connected`, and nothing in the health loop re-runs it — it only checks `killSwitch.Active()`. One bad resolution was therefore permanent until the user reconnected, which tears down the whole WFP session. By then the dead adapter is gone, so the same lookup succeeds — which is why manual always worked and automatic never did.

The handshake keeps working throughout because the daemon's own UDP is covered by the per-IP endpoint permits, not the interface permit. That is exactly the observed "handshake fine, DNS dead" split.

**Fix:** the LUID the manager already holds (`session.windowsLUID`) is plumbed through to the kill switch instead of round-tripping a name, the permitted LUID is logged so a future occurrence is diagnosable from the log alone, and a failed `Update` now fails the bring-up into the existing recovery path rather than reporting a connected-but-unusable session.

## Also here

- **Finding 3:** the tunnel interface metric is pinned to 0 unconditionally, matching `wireguard-windows`. It was gated on an AllowedIPs prefix of `/0` or `/1` existing, which never holds with AllowLAN on (the config decomposes into ~95 prefixes, none wider than `/2`), so the metric stayed automatic.
- Teardown claims the session from the map atomically, so a repair on the health tick cannot re-install a route a concurrent disconnect just removed.

## Hardening from review

Two review passes found real defects in the first draft, both fixed here:

- A tunnel's own default route is on-link (`0.0.0.0/0` via `0.0.0.0`) and passed the default-route election unchallenged. Re-running that election mid-session — which is new in this PR — could have pinned the node's bypass *through* a VPN tunnel: another vendor's, a sibling session's, or the adapter a rebuild was still tearing down. That is the loop the guard exists to prevent. On-link defaults are now skipped and every active tunnel LUID is excluded, not just the session's own.
- The repair adds the new route before removing the old one. When the gateway has merely moved, the old route is still installed and still the session's only way out, so removing first meant a failed add left the node with no path at all.
- Equal-metric defaults break the tie on the lower LUID rather than on `GetIPForwardTable2` iteration order, and a route that was already present is no longer reported as a repair — either could otherwise have had the guard "repairing" every tick, and a repair defers the silence detector.
- Consecutive repairs are capped, so even an unforeseen non-settling route cannot suppress recovery indefinitely.
- A failed kill-switch update tears the half-built session down. Left running it belongs to nobody: no profile is recorded for the health loop to recover, and the next Connect is refused outright by `ensureNoRunningWireGuard`.

## Not in this PR

- **Finding 4** (report `CONNECTING` while handshakes are being retried) — UI-facing and needs the gating rework the issue describes.
- **Finding 5** (unused `RepairNetworkAfterTunnelDisconnect`) — still dead; left for a cleanup.

Neither is implicated in this failure.

## Test plan

- [x] `go test ./...` green on Windows (163 tests across the three touched packages)
- [x] `go vet ./...` clean for windows, linux and darwin, including test files
- [x] Cross-compiles for darwin/arm64, linux/amd64, windows/amd64
- [x] New tests fail without their fix — verified by reverting the health-check hook and watching `TestHealthCheck_RepairedEndpointRouteIsPreferredOverARebuild` fail
- [x] Race detector unavailable on this host (windows/arm64); CI covers it
- [ ] **Manual on the affected host:** confirm a session survives a Wi-Fi flap without the 180s silence + rebuild, and that the log now shows `re-pinned it` instead
- [ ] **Manual:** force a rebuild and check the `kill switch updated ... permitting <name> (LUID n)` line matches `Get-NetAdapter | fl *Luid*` for the live adapter

Reviewers: the interface-metric change (finding 3) is the one place I went slightly beyond the two root causes. It matches upstream `wireguard-windows`, and interface metric only breaks ties between routes of equal prefix length, so a split-tunnel config still cannot attract traffic outside its AllowedIPs — but it is the easiest thing here to disagree with.
