### PR TITLE
chore(release): bump version to 0.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ What you can do instead of taking our word for it:
   ```
   ```powershell
   # Windows
-  Get-FileHash .\PangeaVPN-Setup-0.5.3-x64.exe -Algorithm SHA256
+  Get-FileHash .\PangeaVPN-Setup-0.5.4-x64.exe -Algorithm SHA256
   ```
 - **Check where it was built.** Every release artifact is produced by [GitHub Actions](.github/workflows/build-desktop.yml) from the tagged commit, in public, with public logs.
 - **Build it yourself.** See [Build from source](#build-from-source). You do not have to trust our binaries at all.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pangeavpn/desktop",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "author": {
     "name": "Pangea",

--- a/daemon/cmd/daemon/versioninfo.json
+++ b/daemon/cmd/daemon/versioninfo.json
@@ -3,13 +3,13 @@
     "FileVersion": {
       "Major": 0,
       "Minor": 5,
-       "Patch": 3,
+      "Patch": 4,
       "Build": 0
     },
     "ProductVersion": {
       "Major": 0,
       "Minor": 5,
-       "Patch": 3,
+      "Patch": 4,
       "Build": 0
     },
     "FileFlagsMask": "3f",
@@ -22,13 +22,13 @@
     "Comments": "",
     "CompanyName": "PangeaVPN",
     "FileDescription": "PangeaVPN Daemon",
-    "FileVersion": "0.5.3.0",
+    "FileVersion": "0.5.4.0",
     "InternalName": "PangeaDaemon",
     "LegalCopyright": "Copyright (c) PangeaVPN",
     "OriginalFilename": "PangeaDaemon.exe",
     "PrivateBuild": "",
     "ProductName": "PangeaVPN",
-    "ProductVersion": "0.5.3.0",
+    "ProductVersion": "0.5.4.0",
     "SpecialBuild": ""
   },
   "VarFileInfo": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pangea-vpn",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pangea-vpn",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -17,7 +17,7 @@
     },
     "apps/desktop": {
       "name": "@pangeavpn/desktop",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "dependencies": {
         "@pangeavpn/shared-types": "file:../../packages/shared-types",
         "electron-updater": "^6.8.9"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pangea-vpn",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/scripts/install-mac.sh
+++ b/scripts/install-mac.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 # ── Configuration ────────────────────────────────────────────────────────────
-VERSION="0.5.3"
+VERSION="0.5.4"
 
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'


### PR DESCRIPTION
Patch bump from 0.5.3, covering the Windows tunnel fixes merged in #23.

Same six files the 0.5.3 bump touched:

| File | Change |
| --- | --- |
| `package.json`, `apps/desktop/package.json` | `0.5.3` → `0.5.4` |
| `package-lock.json` | root, workspace root and `apps/desktop` entries |
| `daemon/cmd/daemon/versioninfo.json` | `Patch` 3 → 4, File/ProductVersion `0.5.4.0` |
| `README.md` | Windows installer filename in the checksum example |
| `scripts/install-mac.sh` | `VERSION` |

The Android apps read the number out of the root `package.json` (`apps/android/build.gradle.kts`), so `versionName` becomes `0.5.4` and `versionCode` `504` with no second edit — still monotonic against 503.

Also corrects the indentation the 0.5.3 bump left behind on the two `"Patch"` lines in `versioninfo.json` (7 spaces instead of 6), since those are the lines being edited anyway.

## Test plan

- [x] All four JSON files still parse
- [x] `bash -n scripts/install-mac.sh`
- [x] No `0.5.3` left anywhere outside `node_modules`/`.cache`
- [x] Derived Android `versionCode` recomputed as 504