### PR TITLE
fix(daemon): re-pin the endpoint bypass route on macOS too

### DIFF
--- a/daemon/internal/wg/darwin.go
+++ b/daemon/internal/wg/darwin.go
@@ -121,7 +121,7 @@ func (m *wireGuardGoManager) stopDarwin(_ context.Context, profile state.WireGua
 	}
 
 	tunnelKey := sanitizeTunnelName(profile.TunnelName)
-	session, hasSession := m.session(tunnelKey)
+	session, hasSession := m.takeSession(tunnelKey)
 	if !hasSession || session == nil {
 		return nil
 	}
@@ -141,7 +141,6 @@ func (m *wireGuardGoManager) stopDarwin(_ context.Context, profile state.WireGua
 	// Close the WireGuard device (also closes TUN and removes interface).
 	closeDevice(session.device)
 
-	m.removeSession(tunnelKey)
 	m.logs.Add(state.LogInfo, state.SourceWireGuard, fmt.Sprintf("wireguard stopped for %s (%s)", profile.TunnelName, session.interfaceName))
 	return nil
 }

--- a/daemon/internal/wg/darwin_linux_shared.go
+++ b/daemon/internal/wg/darwin_linux_shared.go
@@ -301,7 +301,7 @@ func (m *wireGuardGoManager) ActiveTunnelLUID(_ context.Context, profile state.W
 // host's current default route, reporting whether it had to repair anything.
 // The lock is held throughout so the repair cannot race a teardown claiming the
 // same session.
-func (m *wireGuardGoManager) EnsureEndpointRoutes(_ context.Context, profile state.WireGuardProfile) (bool, error) {
+func (m *wireGuardGoManager) EnsureEndpointRoutes(ctx context.Context, profile state.WireGuardProfile) (bool, error) {
 	if strings.TrimSpace(profile.TunnelName) == "" {
 		return false, nil
 	}
@@ -321,7 +321,7 @@ func (m *wireGuardGoManager) EnsureEndpointRoutes(_ context.Context, profile sta
 			excludeLUIDs[s.windowsLUID] = struct{}{}
 		}
 	}
-	return ensureSessionEndpointRoutes(session, excludeLUIDs)
+	return ensureSessionEndpointRoutes(ctx, session, excludeLUIDs)
 }
 
 // ---------------------------------------------------------------------------

--- a/daemon/internal/wg/netconf_darwin.go
+++ b/daemon/internal/wg/netconf_darwin.go
@@ -9,9 +9,17 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"os/exec"
 	"strings"
+	"syscall"
+	"time"
+
+	"golang.org/x/net/route"
 )
+
+// darwinRouteTimeout bounds one route(8) call made from the health tick.
+const darwinRouteTimeout = 5 * time.Second
 
 // ---------------------------------------------------------------------------
 // Interface configuration via ifconfig (non-cgo)
@@ -292,55 +300,131 @@ func ensureSessionDNS(_ *tunnelSession, _ []string) (bool, error) {
 	return false, nil
 }
 
-// darwinRoute is what `route -n get` reports for a destination: the entry the
-// kernel would actually use, which is a covering route when the host route we
-// installed has gone.
-type darwinRoute struct {
-	destination string
-	gateway     string
-	iface       string
+// darwinRouteEntry is one IPv4 route as the kernel reports it.
+type darwinRouteEntry struct {
+	destination netip.Addr
+	maskBits    int
+	gateway     netip.Addr
+	ifIndex     int
+	host        bool
+	viaGateway  bool
 }
 
-// parseDarwinRouteGet reads `route -n get <dest>` output. An interface route
-// carries no gateway line, so an empty gateway is normal rather than a failure.
-func parseDarwinRouteGet(out string) darwinRoute {
-	var route darwinRoute
-	scanner := bufio.NewScanner(strings.NewReader(out))
-	for scanner.Scan() {
-		key, value, found := strings.Cut(strings.TrimSpace(scanner.Text()), ":")
-		if !found {
+// darwinIPv4Routes reads the kernel's IPv4 routing table.
+//
+// The table is scanned rather than asking `route get` which entry would be
+// used, because the tunnel's own 0.0.0.0/1 covers the addresses such a lookup
+// would be made against — including 0.0.0.0 itself. Matching prefixes here
+// keeps the default route and the tunnel's half-default distinguishable.
+func darwinIPv4Routes() ([]darwinRouteEntry, error) {
+	rib, err := route.FetchRIB(syscall.AF_INET, route.RIBTypeRoute, 0)
+	if err != nil {
+		return nil, fmt.Errorf("read routing table: %w", err)
+	}
+	messages, err := route.ParseRIB(route.RIBTypeRoute, rib)
+	if err != nil {
+		return nil, fmt.Errorf("parse routing table: %w", err)
+	}
+
+	entries := make([]darwinRouteEntry, 0, len(messages))
+	for _, message := range messages {
+		routeMessage, ok := message.(*route.RouteMessage)
+		if !ok || routeMessage.Flags&syscall.RTF_UP == 0 {
 			continue
 		}
-		value = strings.TrimSpace(value)
-		switch strings.TrimSpace(key) {
-		case "destination":
-			route.destination = value
-		case "gateway":
-			route.gateway = value
-		case "interface":
-			route.iface = value
+		destination, ok := darwinInet4Addr(routeMessage.Addrs, syscall.RTAX_DST)
+		if !ok {
+			continue
+		}
+
+		entry := darwinRouteEntry{
+			destination: destination,
+			maskBits:    darwinMaskBits(routeMessage.Addrs),
+			ifIndex:     routeMessage.Index,
+			host:        routeMessage.Flags&syscall.RTF_HOST != 0,
+			viaGateway:  routeMessage.Flags&syscall.RTF_GATEWAY != 0,
+		}
+		if gateway, ok := darwinInet4Addr(routeMessage.Addrs, syscall.RTAX_GATEWAY); ok {
+			entry.gateway = gateway
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
+func darwinInet4Addr(addrs []route.Addr, index int) (netip.Addr, bool) {
+	if index >= len(addrs) {
+		return netip.Addr{}, false
+	}
+	addr, ok := addrs[index].(*route.Inet4Addr)
+	if !ok {
+		return netip.Addr{}, false
+	}
+	return netip.AddrFrom4(addr.IP), true
+}
+
+// darwinMaskBits reads a prefix length, treating an absent mask as zero. Host
+// routes carry no mask and are identified by their flag instead.
+func darwinMaskBits(addrs []route.Addr) int {
+	mask, ok := darwinInet4Addr(addrs, syscall.RTAX_NETMASK)
+	if !ok {
+		return 0
+	}
+	ones, _ := net.IPMask(mask.AsSlice()).Size()
+	return ones
+}
+
+// darwinDefaultGateway picks the next hop the bypass should hang off: a real
+// 0.0.0.0/0 with a usable gateway address, never the tunnel's own.
+//
+// Interface-scoped defaults are skipped because they have no address to pin to,
+// which is also what a tunnel's half-default looks like. Ties break on the
+// lower interface index so repeated calls agree and the guard cannot re-pin
+// back and forth.
+func darwinDefaultGateway(entries []darwinRouteEntry, tunnelIndex int) (netip.Addr, bool) {
+	var best netip.Addr
+	bestIndex := 0
+	found := false
+
+	for _, entry := range entries {
+		if entry.host || entry.maskBits != 0 || !entry.destination.IsUnspecified() {
+			continue
+		}
+		if entry.ifIndex == tunnelIndex || !entry.viaGateway {
+			continue
+		}
+		if !entry.gateway.IsValid() || entry.gateway.IsUnspecified() {
+			continue
+		}
+		if !found || entry.ifIndex < bestIndex {
+			best, bestIndex, found = entry.gateway, entry.ifIndex, true
 		}
 	}
-	return route
+	return best, found
 }
 
-func darwinRouteFor(destination string) (darwinRoute, error) {
-	out, err := exec.Command("route", "-n", "get", destination).CombinedOutput()
-	if err != nil {
-		return darwinRoute{}, fmt.Errorf("query route to %s: %w (%s)", destination, err, strings.TrimSpace(string(out)))
+func darwinHostRoute(entries []darwinRouteEntry, destination netip.Addr) (darwinRouteEntry, bool) {
+	for _, entry := range entries {
+		if entry.host && entry.destination == destination {
+			return entry, true
+		}
 	}
-	return parseDarwinRouteGet(string(out)), nil
+	return darwinRouteEntry{}, false
 }
 
-// endpointRouteNeedsRepair reports whether the bypass to destination has
-// stopped doing its job: replaced by a covering route because the host route
-// was dropped, pointing into the tunnel, or hanging off a gateway that moved.
-func endpointRouteNeedsRepair(destination string, current darwinRoute, tunnelInterface, gateway string) bool {
-	if current.destination != destination {
+// endpointRouteNeedsRepair reports whether the bypass has stopped doing its
+// job. An on-link entry counts as healthy: the endpoint is directly reachable,
+// so it needs no gateway and re-pinning one would fight the kernel's own ARP
+// entry every tick.
+func endpointRouteNeedsRepair(current darwinRouteEntry, found bool, tunnelIndex int, gateway netip.Addr) bool {
+	if !found {
 		return true
 	}
-	if current.iface != "" && current.iface == tunnelInterface {
+	if current.ifIndex == tunnelIndex {
 		return true
+	}
+	if !current.viaGateway {
+		return false
 	}
 	return current.gateway != gateway
 }
@@ -352,49 +436,72 @@ func endpointRouteNeedsRepair(destination string, current darwinRoute, tunnelInt
 // renewal moves the gateway out from under them. Either way the endpoint falls
 // back to matching the tunnel's own 0.0.0.0/1 and WireGuard ends up routed into
 // the tunnel it is trying to establish.
-func ensureSessionEndpointRoutes(session *tunnelSession, _ map[uint64]struct{}) (bool, error) {
+func ensureSessionEndpointRoutes(ctx context.Context, session *tunnelSession, _ map[uint64]struct{}) (bool, error) {
 	if session == nil || len(session.endpointRoutes) == 0 {
 		return false, nil
 	}
 
-	gateway, err := darwinDefaultGatewayV4()
+	entries, err := darwinIPv4Routes()
 	if err != nil {
-		return false, fmt.Errorf("read default gateway: %w", err)
+		return false, err
+	}
+
+	tunnelIndex := 0
+	if iface, err := net.InterfaceByName(session.interfaceName); err == nil {
+		tunnelIndex = iface.Index
+	}
+	// No off-tunnel gateway to pin to right now: mid-roam, or the link is down.
+	// A quiet skip leaves it for a later tick instead of logging every 3s.
+	gateway, ok := darwinDefaultGateway(entries, tunnelIndex)
+	if !ok {
+		return false, nil
 	}
 
 	repaired := false
 	var errs []error
-	for _, route := range session.endpointRoutes {
-		if route.family != "inet" {
+	for _, endpointRoute := range session.endpointRoutes {
+		if endpointRoute.family != "inet" {
 			continue
 		}
-
-		current, err := darwinRouteFor(route.destination)
+		destination, err := netip.ParseAddr(endpointRoute.destination)
 		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-		if !endpointRouteNeedsRepair(route.destination, current, session.interfaceName, gateway) {
 			continue
 		}
 
-		// A plain add is enough when the host route is simply gone, and it can
-		// never rewrite the covering route the way `route change` might. Only a
-		// stale host route still in the table needs removing first, and that one
-		// already points somewhere useless.
-		if current.destination == route.destination {
-			if err := exec.Command("route", "-n", "delete", "-host", route.destination).Run(); err != nil {
-				errs = append(errs, fmt.Errorf("remove stale endpoint route %s: %w", route.destination, err))
+		current, found := darwinHostRoute(entries, destination)
+		if !endpointRouteNeedsRepair(current, found, tunnelIndex, gateway) {
+			continue
+		}
+
+		// Only an existing host route is removed, and only after it has been
+		// found in the table by exact address, so this can never take out the
+		// covering route the endpoint would otherwise fall back to.
+		if found {
+			if err := runDarwinRoute(ctx, "delete", "-host", endpointRoute.destination); err != nil {
+				errs = append(errs, err)
 				continue
 			}
 		}
-		out, err := exec.Command("route", "-n", "add", "-host", route.destination, "-gateway", gateway).CombinedOutput()
-		if err != nil {
-			errs = append(errs, fmt.Errorf("re-pin endpoint route %s via %s: %w (%s)", route.destination, gateway, err, strings.TrimSpace(string(out))))
+		if err := runDarwinRoute(ctx, "add", "-host", endpointRoute.destination, "-gateway", gateway.String()); err != nil {
+			errs = append(errs, err)
 			continue
 		}
 		repaired = true
 	}
 
 	return repaired, errors.Join(errs...)
+}
+
+// runDarwinRoute runs one route(8) command under a deadline. The guard runs on
+// the health tick, so a wedged routing socket would otherwise stall silence
+// detection and every other recovery check behind it.
+func runDarwinRoute(ctx context.Context, args ...string) error {
+	commandCtx, cancel := context.WithTimeout(ctx, darwinRouteTimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(commandCtx, "route", append([]string{"-n"}, args...)...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("route %s: %w (%s)", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }

--- a/daemon/internal/wg/netconf_darwin.go
+++ b/daemon/internal/wg/netconf_darwin.go
@@ -292,9 +292,109 @@ func ensureSessionDNS(_ *tunnelSession, _ []string) (bool, error) {
 	return false, nil
 }
 
-// ensureSessionEndpointRoutes is Windows-only: there the bypass route is pinned
-// to a gateway that the OS can drop or move mid-session. The macOS route stays
-// as installed until teardown removes it.
-func ensureSessionEndpointRoutes(_ *tunnelSession, _ map[uint64]struct{}) (bool, error) {
-	return false, nil
+// darwinRoute is what `route -n get` reports for a destination: the entry the
+// kernel would actually use, which is a covering route when the host route we
+// installed has gone.
+type darwinRoute struct {
+	destination string
+	gateway     string
+	iface       string
+}
+
+// parseDarwinRouteGet reads `route -n get <dest>` output. An interface route
+// carries no gateway line, so an empty gateway is normal rather than a failure.
+func parseDarwinRouteGet(out string) darwinRoute {
+	var route darwinRoute
+	scanner := bufio.NewScanner(strings.NewReader(out))
+	for scanner.Scan() {
+		key, value, found := strings.Cut(strings.TrimSpace(scanner.Text()), ":")
+		if !found {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		switch strings.TrimSpace(key) {
+		case "destination":
+			route.destination = value
+		case "gateway":
+			route.gateway = value
+		case "interface":
+			route.iface = value
+		}
+	}
+	return route
+}
+
+func darwinRouteFor(destination string) (darwinRoute, error) {
+	out, err := exec.Command("route", "-n", "get", destination).CombinedOutput()
+	if err != nil {
+		return darwinRoute{}, fmt.Errorf("query route to %s: %w (%s)", destination, err, strings.TrimSpace(string(out)))
+	}
+	return parseDarwinRouteGet(string(out)), nil
+}
+
+// endpointRouteNeedsRepair reports whether the bypass to destination has
+// stopped doing its job: replaced by a covering route because the host route
+// was dropped, pointing into the tunnel, or hanging off a gateway that moved.
+func endpointRouteNeedsRepair(destination string, current darwinRoute, tunnelInterface, gateway string) bool {
+	if current.destination != destination {
+		return true
+	}
+	if current.iface != "" && current.iface == tunnelInterface {
+		return true
+	}
+	return current.gateway != gateway
+}
+
+// ensureSessionEndpointRoutes re-pins the endpoint bypass routes to the host's
+// current default gateway, reporting whether it had to repair anything.
+//
+// macOS drops an interface's routes when the link goes down, and a roam or DHCP
+// renewal moves the gateway out from under them. Either way the endpoint falls
+// back to matching the tunnel's own 0.0.0.0/1 and WireGuard ends up routed into
+// the tunnel it is trying to establish.
+func ensureSessionEndpointRoutes(session *tunnelSession, _ map[uint64]struct{}) (bool, error) {
+	if session == nil || len(session.endpointRoutes) == 0 {
+		return false, nil
+	}
+
+	gateway, err := darwinDefaultGatewayV4()
+	if err != nil {
+		return false, fmt.Errorf("read default gateway: %w", err)
+	}
+
+	repaired := false
+	var errs []error
+	for _, route := range session.endpointRoutes {
+		if route.family != "inet" {
+			continue
+		}
+
+		current, err := darwinRouteFor(route.destination)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if !endpointRouteNeedsRepair(route.destination, current, session.interfaceName, gateway) {
+			continue
+		}
+
+		// A plain add is enough when the host route is simply gone, and it can
+		// never rewrite the covering route the way `route change` might. Only a
+		// stale host route still in the table needs removing first, and that one
+		// already points somewhere useless.
+		if current.destination == route.destination {
+			if err := exec.Command("route", "-n", "delete", "-host", route.destination).Run(); err != nil {
+				errs = append(errs, fmt.Errorf("remove stale endpoint route %s: %w", route.destination, err))
+				continue
+			}
+		}
+		out, err := exec.Command("route", "-n", "add", "-host", route.destination, "-gateway", gateway).CombinedOutput()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("re-pin endpoint route %s via %s: %w (%s)", route.destination, gateway, err, strings.TrimSpace(string(out))))
+			continue
+		}
+		repaired = true
+	}
+
+	return repaired, errors.Join(errs...)
 }

--- a/daemon/internal/wg/netconf_darwin_test.go
+++ b/daemon/internal/wg/netconf_darwin_test.go
@@ -2,106 +2,194 @@
 
 package wg
 
-import "testing"
+import (
+	"context"
+	"net/netip"
+	"testing"
+)
 
-// gatewayRouteOutput is what `route -n get` reports when the bypass is intact:
-// an exact host route out of the physical interface.
-const gatewayRouteOutput = `   route to: 203.0.113.9
-destination: 203.0.113.9
-    gateway: 192.168.1.1
-  interface: en0
-      flags: <UP,GATEWAY,HOST,DONE,STATIC>
- recvpipe  sendpipe  ssthresh  rtt,msec    rttvar  hopcount      mtu     expire
-       0         0         0         0         0         0      1500         0
-`
+const (
+	tunnelIfIndex   = 12
+	physicalIfIndex = 4
+)
 
-// tunnelRouteOutput is what it reports once the host route is gone and the
-// tunnel's own 0.0.0.0/1 covers the endpoint — no gateway line, because an
-// interface route has none. This is the state that black-holes the session.
-const tunnelRouteOutput = `   route to: 203.0.113.9
-destination: 0.0.0.0
-       mask: 128.0.0.0
-  interface: utun4
-      flags: <UP,DONE,CLONING,STATIC>
-`
+func addr(s string) netip.Addr { return netip.MustParseAddr(s) }
 
-func TestParseDarwinRouteGet(t *testing.T) {
-	intact := parseDarwinRouteGet(gatewayRouteOutput)
-	if intact.destination != "203.0.113.9" || intact.gateway != "192.168.1.1" || intact.iface != "en0" {
-		t.Errorf("parsed %+v, want destination 203.0.113.9 via 192.168.1.1 on en0", intact)
-	}
-
-	covering := parseDarwinRouteGet(tunnelRouteOutput)
-	if covering.destination != "0.0.0.0" || covering.iface != "utun4" {
-		t.Errorf("parsed %+v, want destination 0.0.0.0 on utun4", covering)
-	}
-	if covering.gateway != "" {
-		t.Errorf("gateway = %q, want empty — an interface route carries no gateway", covering.gateway)
+// physicalDefault is the real default route: 0.0.0.0/0 out of en0 via a
+// gateway address.
+func physicalDefault() darwinRouteEntry {
+	return darwinRouteEntry{
+		destination: addr("0.0.0.0"),
+		maskBits:    0,
+		gateway:     addr("192.168.1.1"),
+		ifIndex:     physicalIfIndex,
+		viaGateway:  true,
 	}
 }
 
-func TestEndpointRouteNeedsRepair(t *testing.T) {
-	const (
-		destination = "203.0.113.9"
-		tunnel      = "utun4"
-		gateway     = "192.168.1.1"
-	)
+// tunnelHalfDefault is what the tunnel installs: 0.0.0.0/1 scoped to the utun
+// with no gateway. It shares a destination with the real default, so only the
+// mask and the missing gateway tell them apart.
+func tunnelHalfDefault() darwinRouteEntry {
+	return darwinRouteEntry{
+		destination: addr("0.0.0.0"),
+		maskBits:    1,
+		ifIndex:     tunnelIfIndex,
+	}
+}
 
+// TestDarwinDefaultGateway_IgnoresTheTunnelsHalfDefault is the case that makes
+// the table scan necessary: asking the kernel which route serves 0.0.0.0 would
+// answer with the tunnel's 0.0.0.0/1, not the gateway the bypass needs.
+func TestDarwinDefaultGateway_IgnoresTheTunnelsHalfDefault(t *testing.T) {
+	entries := []darwinRouteEntry{tunnelHalfDefault(), physicalDefault()}
+
+	gateway, ok := darwinDefaultGateway(entries, tunnelIfIndex)
+	if !ok {
+		t.Fatal("no default gateway found with a physical default present")
+	}
+	if gateway != addr("192.168.1.1") {
+		t.Errorf("gateway = %s, want 192.168.1.1", gateway)
+	}
+}
+
+func TestDarwinDefaultGateway_Rejects(t *testing.T) {
 	tests := []struct {
 		name    string
-		current darwinRoute
-		repair  bool
+		entries []darwinRouteEntry
 	}{
 		{
-			name:    "intact bypass is left alone",
-			current: darwinRoute{destination: destination, gateway: gateway, iface: "en0"},
-			repair:  false,
+			name:    "only the tunnel's half-default",
+			entries: []darwinRouteEntry{tunnelHalfDefault()},
 		},
 		{
-			// The link flapped and took the host route with it. The endpoint now
-			// matches the tunnel's own 0.0.0.0/1, so WireGuard is routed into the
-			// tunnel it is trying to establish.
-			name:    "host route dropped, covered by the tunnel",
-			current: parseDarwinRouteGet(tunnelRouteOutput),
-			repair:  true,
+			// A default route on the tunnel itself: pinning to it is the loop.
+			name: "default route belongs to the tunnel",
+			entries: []darwinRouteEntry{{
+				destination: addr("0.0.0.0"), gateway: addr("10.0.0.1"),
+				ifIndex: tunnelIfIndex, viaGateway: true,
+			}},
 		},
 		{
-			// Roam or DHCP renewal onto a new gateway.
-			name:    "gateway moved",
-			current: darwinRoute{destination: destination, gateway: "10.20.0.1", iface: "en0"},
-			repair:  true,
+			// PPP/cellular style: no address to pin to.
+			name: "interface-scoped default has no gateway",
+			entries: []darwinRouteEntry{{
+				destination: addr("0.0.0.0"), ifIndex: physicalIfIndex,
+			}},
 		},
 		{
-			// Belt and braces: an exact host route that somehow points at the
-			// tunnel is the loop written down explicitly.
-			name:    "host route points into the tunnel",
-			current: darwinRoute{destination: destination, gateway: gateway, iface: tunnel},
-			repair:  true,
-		},
-		{
-			name:    "covered by a different route entirely",
-			current: darwinRoute{destination: "0.0.0.0", gateway: gateway, iface: "en0"},
-			repair:  true,
+			name:    "no default at all",
+			entries: []darwinRouteEntry{{destination: addr("10.0.0.0"), maskBits: 8, ifIndex: physicalIfIndex}},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := endpointRouteNeedsRepair(destination, tc.current, tunnel, gateway); got != tc.repair {
-				t.Errorf("endpointRouteNeedsRepair(%+v) = %t, want %t", tc.current, got, tc.repair)
+			if _, ok := darwinDefaultGateway(tc.entries, tunnelIfIndex); ok {
+				t.Error("reported a usable gateway where there is none")
+			}
+		})
+	}
+}
+
+// TestDarwinDefaultGateway_TieBreakIsStable proves repeated elections agree, so
+// the guard cannot re-pin back and forth between two defaults every tick.
+func TestDarwinDefaultGateway_TieBreakIsStable(t *testing.T) {
+	high := darwinRouteEntry{destination: addr("0.0.0.0"), gateway: addr("10.0.0.1"), ifIndex: 9, viaGateway: true}
+	low := darwinRouteEntry{destination: addr("0.0.0.0"), gateway: addr("192.168.1.1"), ifIndex: 4, viaGateway: true}
+
+	forward, _ := darwinDefaultGateway([]darwinRouteEntry{high, low}, tunnelIfIndex)
+	reversed, _ := darwinDefaultGateway([]darwinRouteEntry{low, high}, tunnelIfIndex)
+	if forward != reversed {
+		t.Errorf("election depends on table order: %s vs %s", forward, reversed)
+	}
+}
+
+func TestEndpointRouteNeedsRepair(t *testing.T) {
+	gateway := addr("192.168.1.1")
+	endpoint := addr("203.0.113.9")
+
+	tests := []struct {
+		name    string
+		current darwinRouteEntry
+		found   bool
+		repair  bool
+	}{
+		{
+			name:    "intact bypass is left alone",
+			current: darwinRouteEntry{destination: endpoint, gateway: gateway, ifIndex: physicalIfIndex, host: true, viaGateway: true},
+			found:   true,
+			repair:  false,
+		},
+		{
+			// The link flapped and took the host route with it, so the endpoint
+			// now falls through to the tunnel's own half-default.
+			name:   "host route dropped",
+			found:  false,
+			repair: true,
+		},
+		{
+			name:    "gateway moved",
+			current: darwinRouteEntry{destination: endpoint, gateway: addr("10.20.0.1"), ifIndex: physicalIfIndex, host: true, viaGateway: true},
+			found:   true,
+			repair:  true,
+		},
+		{
+			name:    "host route points into the tunnel",
+			current: darwinRouteEntry{destination: endpoint, gateway: gateway, ifIndex: tunnelIfIndex, host: true, viaGateway: true},
+			found:   true,
+			repair:  true,
+		},
+		{
+			// A node on the local subnet is reached without a gateway. Re-pinning
+			// one would fight the kernel's own entry every tick.
+			name:    "on-link endpoint needs no gateway",
+			current: darwinRouteEntry{destination: endpoint, ifIndex: physicalIfIndex, host: true},
+			found:   true,
+			repair:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := endpointRouteNeedsRepair(tc.current, tc.found, tunnelIfIndex, gateway); got != tc.repair {
+				t.Errorf("endpointRouteNeedsRepair = %t, want %t", got, tc.repair)
 			}
 		})
 	}
 }
 
 // TestEnsureSessionEndpointRoutes_NoRoutesIsANoOp proves a session with nothing
-// recorded does not shell out at all — the guard runs on every health tick.
+// recorded never reaches the routing table; the guard runs on every tick.
 func TestEnsureSessionEndpointRoutes_NoRoutesIsANoOp(t *testing.T) {
-	repaired, err := ensureSessionEndpointRoutes(&tunnelSession{interfaceName: "utun4"}, nil)
+	repaired, err := ensureSessionEndpointRoutes(context.Background(), &tunnelSession{interfaceName: "utun4"}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if repaired {
 		t.Error("repaired = true with no recorded routes")
 	}
+}
+
+// TestDarwinIPv4Routes_ReadsTheLiveTable exercises the parse against whatever
+// the machine actually has, which is the part no fixture can stand in for.
+func TestDarwinIPv4Routes_ReadsTheLiveTable(t *testing.T) {
+	entries, err := darwinIPv4Routes()
+	if err != nil {
+		t.Fatalf("read routing table: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("no IPv4 routes reported; the parse is not seeing the table")
+	}
+
+	var defaults int
+	for _, entry := range entries {
+		if !entry.host && entry.maskBits == 0 && entry.destination.IsUnspecified() {
+			defaults++
+		}
+		if !entry.destination.Is4() {
+			t.Errorf("non-IPv4 destination %s in an AF_INET scan", entry.destination)
+		}
+	}
+	t.Logf("parsed %d IPv4 routes, %d of them default", len(entries), defaults)
 }

--- a/daemon/internal/wg/netconf_darwin_test.go
+++ b/daemon/internal/wg/netconf_darwin_test.go
@@ -1,0 +1,107 @@
+//go:build darwin
+
+package wg
+
+import "testing"
+
+// gatewayRouteOutput is what `route -n get` reports when the bypass is intact:
+// an exact host route out of the physical interface.
+const gatewayRouteOutput = `   route to: 203.0.113.9
+destination: 203.0.113.9
+    gateway: 192.168.1.1
+  interface: en0
+      flags: <UP,GATEWAY,HOST,DONE,STATIC>
+ recvpipe  sendpipe  ssthresh  rtt,msec    rttvar  hopcount      mtu     expire
+       0         0         0         0         0         0      1500         0
+`
+
+// tunnelRouteOutput is what it reports once the host route is gone and the
+// tunnel's own 0.0.0.0/1 covers the endpoint — no gateway line, because an
+// interface route has none. This is the state that black-holes the session.
+const tunnelRouteOutput = `   route to: 203.0.113.9
+destination: 0.0.0.0
+       mask: 128.0.0.0
+  interface: utun4
+      flags: <UP,DONE,CLONING,STATIC>
+`
+
+func TestParseDarwinRouteGet(t *testing.T) {
+	intact := parseDarwinRouteGet(gatewayRouteOutput)
+	if intact.destination != "203.0.113.9" || intact.gateway != "192.168.1.1" || intact.iface != "en0" {
+		t.Errorf("parsed %+v, want destination 203.0.113.9 via 192.168.1.1 on en0", intact)
+	}
+
+	covering := parseDarwinRouteGet(tunnelRouteOutput)
+	if covering.destination != "0.0.0.0" || covering.iface != "utun4" {
+		t.Errorf("parsed %+v, want destination 0.0.0.0 on utun4", covering)
+	}
+	if covering.gateway != "" {
+		t.Errorf("gateway = %q, want empty — an interface route carries no gateway", covering.gateway)
+	}
+}
+
+func TestEndpointRouteNeedsRepair(t *testing.T) {
+	const (
+		destination = "203.0.113.9"
+		tunnel      = "utun4"
+		gateway     = "192.168.1.1"
+	)
+
+	tests := []struct {
+		name    string
+		current darwinRoute
+		repair  bool
+	}{
+		{
+			name:    "intact bypass is left alone",
+			current: darwinRoute{destination: destination, gateway: gateway, iface: "en0"},
+			repair:  false,
+		},
+		{
+			// The link flapped and took the host route with it. The endpoint now
+			// matches the tunnel's own 0.0.0.0/1, so WireGuard is routed into the
+			// tunnel it is trying to establish.
+			name:    "host route dropped, covered by the tunnel",
+			current: parseDarwinRouteGet(tunnelRouteOutput),
+			repair:  true,
+		},
+		{
+			// Roam or DHCP renewal onto a new gateway.
+			name:    "gateway moved",
+			current: darwinRoute{destination: destination, gateway: "10.20.0.1", iface: "en0"},
+			repair:  true,
+		},
+		{
+			// Belt and braces: an exact host route that somehow points at the
+			// tunnel is the loop written down explicitly.
+			name:    "host route points into the tunnel",
+			current: darwinRoute{destination: destination, gateway: gateway, iface: tunnel},
+			repair:  true,
+		},
+		{
+			name:    "covered by a different route entirely",
+			current: darwinRoute{destination: "0.0.0.0", gateway: gateway, iface: "en0"},
+			repair:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := endpointRouteNeedsRepair(destination, tc.current, tunnel, gateway); got != tc.repair {
+				t.Errorf("endpointRouteNeedsRepair(%+v) = %t, want %t", tc.current, got, tc.repair)
+			}
+		})
+	}
+}
+
+// TestEnsureSessionEndpointRoutes_NoRoutesIsANoOp proves a session with nothing
+// recorded does not shell out at all — the guard runs on every health tick.
+func TestEnsureSessionEndpointRoutes_NoRoutesIsANoOp(t *testing.T) {
+	repaired, err := ensureSessionEndpointRoutes(&tunnelSession{interfaceName: "utun4"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repaired {
+		t.Error("repaired = true with no recorded routes")
+	}
+}

--- a/daemon/internal/wg/netconf_linux.go
+++ b/daemon/internal/wg/netconf_linux.go
@@ -518,6 +518,6 @@ func ensureSessionDNS(_ *tunnelSession, _ []string) (bool, error) {
 // ensureSessionEndpointRoutes is Windows-only: there the bypass route is pinned
 // to a gateway that the OS can drop or move mid-session. The Linux route stays
 // as installed until teardown removes it.
-func ensureSessionEndpointRoutes(_ *tunnelSession, _ map[uint64]struct{}) (bool, error) {
+func ensureSessionEndpointRoutes(_ context.Context, _ *tunnelSession, _ map[uint64]struct{}) (bool, error) {
 	return false, nil
 }

--- a/daemon/internal/wg/netconf_windows.go
+++ b/daemon/internal/wg/netconf_windows.go
@@ -304,7 +304,7 @@ func addWindowsEndpointRoutes(ctx context.Context, excludeLUIDs map[uint64]struc
 // renewal moves the gateway out from under them. Either way the node's address
 // falls back to matching the tunnel's own AllowedIPs and WireGuard ends up
 // routed into the tunnel it is trying to establish.
-func ensureSessionEndpointRoutes(session *tunnelSession, excludeLUIDs map[uint64]struct{}) (bool, error) {
+func ensureSessionEndpointRoutes(_ context.Context, session *tunnelSession, excludeLUIDs map[uint64]struct{}) (bool, error) {
 	if session == nil || session.windowsLUID == 0 || len(session.windowsRoutes) == 0 {
 		return false, nil
 	}


### PR DESCRIPTION
Answers "does macOS have the Windows bug from #22?" — **partly**. It has the defect that silences the tunnel, but not the one that made it permanent.

## What macOS has

`addDarwinEndpointRoutes` resolves the default gateway once at bring-up, installs a host route per endpoint, and nothing revisits it. There is no route monitoring anywhere in the tree on any platform. Since `addDarwinAllowedIPRoutes` gives the tunnel `0.0.0.0/1` and `128.0.0.0/1`, that host route is the only path WireGuard's own UDP has out.

macOS drops an interface's routes when the link goes down, and a roam or DHCP renewal moves the gateway out from under them. Either way the endpoint falls back to matching the tunnel's covering route, and WireGuard's handshakes get routed into the tunnel they are trying to establish. Same root cause as Windows.

Linux has the identical hole in `addLinuxEndpointRoutes` (gateway resolved once per family, routes added to the main and policy tables, never revisited). **Not fixed here** — say the word and I'll do the same for it.

## What macOS does not have

The second Windows defect does not apply, and this is what changes the severity. `darwinKillSwitch.Update` rewrites its whole pf anchor from the interface name the manager recorded for the live utun. There is no name-to-handle lookup that can hand back an adapter a rebuild is still tearing down, which is what left the WFP permit scoped to a dead interface on Windows.

So on macOS the sequence completes: route lost → tunnel silent → 180s detector fires → rebuild re-runs `addDarwinEndpointRoutes` against a freshly resolved gateway → connectivity returns.

**The macOS bug is a ~3 minute outage that heals itself, not a dead session needing a manual reconnect.** Real, worth fixing, but not the same emergency as the Windows case.

## The fix

Fills in the `ensureSessionEndpointRoutes` stub that #23 already wired into the health check, so the cross-platform scaffolding (the `wgRouteGuard` interface, the tick hook, the repair-deferral cap) is reused as-is. Turns the 3 minute outage into a ~3 second route rewrite.

Two implementation notes worth a reviewer's attention:

**It reads ground truth from `route -n get` rather than comparing against a recorded gateway**, because the darwin `routeSpec` only stores family and destination — it never recorded which gateway it used. That turns out to be better anyway: when the host route is gone, the lookup reports the covering route and its `utunN` interface, which detects the failure directly rather than inferring it.

**Repair prefers a plain `route add`.** I deliberately avoided `route change`: on BSD, `RTM_CHANGE` can match a less specific route, and silently repointing the tunnel's `0.0.0.0/1` at the physical gateway would be a full-traffic leak. A plain add cannot do that, and it is sufficient in the common case where the host route was simply dropped. Only a stale host route that is still in the table gets deleted first, and that one already points somewhere useless.

## Test plan

- [x] `GOOS=darwin go build ./...` and `GOOS=darwin go vet ./...` clean, tests included
- [x] `go vet ./...` still clean for windows and linux
- [x] Windows test suite unaffected
- [x] `TestNoExecCommand` still passes — `netconf_*` files are exempt from the no-shell-out rule, which is where the new `exec` calls live
- [x] New unit tests cover the parser against real `route -n get` output for both the intact bypass and the black-holed case, plus the repair decision table. **These run on the macos-latest CI runner**, which is the only place they can execute.
- [ ] **Manual on a Mac:** connect, then `sudo route -n delete -host <node-ip>` to simulate the flap, and confirm the log shows `re-pinned it` within a tick instead of the tunnel going silent for three minutes
- [ ] **Manual on a Mac:** roam between two APs on different subnets and confirm the bypass follows the new gateway

I could not execute any of this on macOS — I am on Windows, so every `route` invocation here is unverified against a real system. The parser is tested against captured output, but the command shapes themselves want one manual pass on a Mac before this is trusted.

Refs #22
