### PR TITLE
feat(multihop): entry/exit node separation (daemon + client contract)

### DIFF
--- a/apps/desktop/src/main/pangeaApiClient.ts
+++ b/apps/desktop/src/main/pangeaApiClient.ts
@@ -134,6 +134,14 @@ interface RegisterResponse {
   assignedIP: string;
   dns: string;
   existingConfig?: boolean;
+  /** Present only when the request named an entryRegion. See HopProfileSchema. */
+  hop?: {
+    singBoxPort: number;
+    cloakProxyMethod: string;
+    naiveBridgePort?: number;
+    entryRegion: string;
+    exitRegion: string;
+  };
 }
 
 interface DohAnswer {
@@ -1709,11 +1717,25 @@ export class PangeaApiClient {
     this.onHubShadowsocks?.(this.hubShadowsocks);
   }
 
-  async provision(serverId: string, signal?: AbortSignal): Promise<Profile> {
+  async provision(
+    serverId: string,
+    signal?: AbortSignal,
+    entryServerId?: string
+  ): Promise<Profile> {
     if (!this.licenseKey) throw new Error("Not authenticated");
 
-    const server = this.cachedServers.find((s) => s.id === serverId);
-    if (!server) throw new Error(`Unknown server: ${serverId}`);
+    const exitServer = this.cachedServers.find((s) => s.id === serverId);
+    if (!exitServer) throw new Error(`Unknown server: ${serverId}`);
+
+    // Transports terminate on the entry node; the WireGuard peer lives on the
+    // exit. `server` stays the entry below, because every credential block
+    // describes where a transport dials — which is also why excludeIPs keeps
+    // naming only entry addresses.
+    const isMultihop = Boolean(entryServerId && entryServerId !== serverId);
+    const server = isMultihop
+      ? this.cachedServers.find((s) => s.id === entryServerId)
+      : exitServer;
+    if (!server) throw new Error(`Unknown entry server: ${entryServerId}`);
 
     // Ephemeral WG keypair — generated fresh per connection, never stored
     const keyPair = generateWireGuardKeyPair();
@@ -1725,7 +1747,8 @@ export class PangeaApiClient {
         licenseKey: this.licenseKey,
         identityPubkey: this.identityPubkey,
         wgPubkey: keyPair.publicKey,
-        region: serverId
+        region: serverId,
+        ...(isMultihop ? { entryRegion: entryServerId } : {})
       },
       signal
     );
@@ -1784,7 +1807,8 @@ export class PangeaApiClient {
 
     return {
       id: `auto-${serverId}`,
-      name: `${server.name} (auto)`,
+      name: `${exitServer.name} (auto)`,
+      ...(reg.hop ? { hop: reg.hop } : {}),
       cloak: {
         localPort: 51820,
         remoteHost: server.cloak.remoteHost,

--- a/daemon/internal/api/hop_leak_test.go
+++ b/daemon/internal/api/hop_leak_test.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pangeavpn/pangeavpn-desktop/daemon/internal/state"
+)
+
+// The exit node's address must never reach the kill-switch permit list or the
+// WireGuard bypass list. The client dials only the entry; permitting the exit
+// would punch a hole for a host nothing connects to, and exclude it from
+// AllowedIPs so traffic aimed at it would leave in the clear.
+const (
+	entryIP = "192.0.2.10"
+	exitIP  = "198.51.100.20"
+)
+
+func multihopProfile() state.Profile {
+	profile := state.Profile{
+		ID:                   "auto-us-east-1",
+		Cloak:                state.CloakProfile{LocalPort: 51820, RemoteHost: entryIP, RemotePort: 443},
+		Naive:                &state.NaiveProfile{RemoteHost: entryIP, RemotePort: 8443},
+		Reality:              &state.RealityProfile{RemoteHost: entryIP, RemotePort: 8444},
+		Hysteria2:            &state.Hysteria2Profile{RemoteHost: entryIP, RemotePort: 443},
+		Shadowsocks:          &state.ShadowsocksProfile{RemoteHost: entryIP, RemotePort: 8488},
+		TransportEndpointIPs: []string{entryIP},
+		Hop: &state.HopProfile{
+			SingBoxPort: 51831, CloakProxyMethod: "wireguard-via-us-east-1",
+			NaiveBridgePort: 9002, EntryRegion: "eu-west-1", ExitRegion: "us-east-1",
+		},
+		WireGuard: state.WireGuardProfile{
+			// The peer endpoint is always loopback: the transport carries it.
+			ConfigText: "[Peer]\nEndpoint = 127.0.0.1:51820\n",
+		},
+	}
+	return state.ApplyHop(profile)
+}
+
+func TestKillSwitchPermitsExcludeTheExitNode(t *testing.T) {
+	permits := killSwitchPermits(multihopProfile())
+
+	if len(permits) == 0 {
+		t.Fatal("no permits produced; the entry must still be reachable")
+	}
+	for _, permit := range permits {
+		if strings.Contains(permit, exitIP) {
+			t.Errorf("kill switch permits the exit node %q: %v", exitIP, permits)
+		}
+	}
+	if !containsHost(permits, entryIP) {
+		t.Errorf("kill switch does not permit the entry node %q: %v", entryIP, permits)
+	}
+}
+
+func TestBypassHostsExcludeTheExitNode(t *testing.T) {
+	bypass := withTransportBypassHosts(multihopProfile()).BypassHosts
+
+	for _, host := range bypass {
+		if strings.Contains(host, exitIP) {
+			t.Errorf("bypass list routes the exit node %q outside the tunnel: %v", exitIP, bypass)
+		}
+	}
+	if !containsHost(bypass, entryIP) {
+		t.Errorf("bypass list omits the entry node %q, so its dial would recurse: %v", entryIP, bypass)
+	}
+}
+
+// The WireGuard peer endpoint stays on loopback under multihop: the exit is
+// reached through the transport, never dialled directly.
+func TestMultihopWireGuardEndpointStaysLoopback(t *testing.T) {
+	config := multihopProfile().WireGuard.ConfigText
+	if strings.Contains(config, exitIP) {
+		t.Errorf("wireguard config names the exit node directly:\n%s", config)
+	}
+	if !strings.Contains(config, "Endpoint = 127.0.0.1") {
+		t.Errorf("wireguard peer endpoint is not loopback:\n%s", config)
+	}
+}
+
+func containsHost(hosts []string, want string) bool {
+	for _, host := range hosts {
+		if host == want {
+			return true
+		}
+	}
+	return false
+}

--- a/daemon/internal/api/service.go
+++ b/daemon/internal/api/service.go
@@ -537,6 +537,7 @@ func (s *Service) Connect(ctx context.Context, profileID string, opts ConnectOpt
 	if err := validateProfile(profile); err != nil {
 		return err
 	}
+	profile = state.ApplyHop(profile)
 
 	currentState, _ := s.machine.Get()
 	if currentState == state.StateConnecting || currentState == state.StateDisconnecting {
@@ -1611,6 +1612,7 @@ func (s *Service) Switch(ctx context.Context, newProfileID string, opts ConnectO
 	if err := validateProfile(newProfile); err != nil {
 		return err
 	}
+	newProfile = state.ApplyHop(newProfile)
 
 	s.logs.Add(state.LogInfo, state.SourceDaemon, fmt.Sprintf("switch requested: %s -> %s (kill switch stays active)", oldProfile.ID, newProfile.ID))
 
@@ -3677,6 +3679,11 @@ func (s *Service) getCurrentProfile() (state.Profile, bool) {
 func validateProfile(profile state.Profile) error {
 	if profile.ID == "" {
 		return errors.New("profile id is required")
+	}
+	// A half-specified hop would leave some transports pointed at the entry's
+	// own WireGuard listener, quietly egressing one hop early.
+	if err := state.ValidateHop(profile); err != nil {
+		return err
 	}
 	if profile.Cloak.LocalPort <= 0 {
 		return errors.New("cloak.localPort must be > 0")

--- a/daemon/internal/cloak/manager.go
+++ b/daemon/internal/cloak/manager.go
@@ -466,9 +466,16 @@ func buildRawConfig(profile state.CloakProfile, remoteHost string) (*client.RawC
 		remotePort = "443"
 	}
 
+	// The server resolves this against its own ProxyBook, so an exit the node
+	// was not configured for is refused there rather than relayed.
+	proxyMethod := profile.ProxyMethod
+	if proxyMethod == "" {
+		proxyMethod = state.DefaultCloakProxyMethod
+	}
+
 	return &client.RawConfig{
 		ServerName:       serverName,
-		ProxyMethod:      "wireguard",
+		ProxyMethod:      proxyMethod,
 		EncryptionMethod: encMethod,
 		UID:              uid,
 		PublicKey:        pubKey,

--- a/daemon/internal/hysteria2/bridge.go
+++ b/daemon/internal/hysteria2/bridge.go
@@ -73,14 +73,14 @@ func (g *rateGate) allow(interval time.Duration) bool {
 // newUDPBridge opens the WG-facing loopback socket, establishes a SOCKS5
 // UDP ASSOCIATE session against the mixed inbound at mixedAddr, and starts
 // pumping datagrams in both directions.
-func newUDPBridge(ctx context.Context, logs *state.LogStore, localPort int, mixedAddr string) (*udpBridge, error) {
+func newUDPBridge(ctx context.Context, logs *state.LogStore, localPort int, mixedAddr string, targetPort int) (*udpBridge, error) {
 	localAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: localPort}
 	local, err := listenUDPWithRetry(ctx, localAddr, 10, 100*time.Millisecond)
 	if err != nil {
 		return nil, fmt.Errorf("hysteria2: listen local udp: %w", err)
 	}
 
-	target, err := net.ResolveUDPAddr("udp", relayDestination)
+	target, err := net.ResolveUDPAddr("udp", relayDestination(targetPort))
 	if err != nil {
 		local.Close()
 		return nil, fmt.Errorf("hysteria2: resolve relay destination: %w", err)

--- a/daemon/internal/hysteria2/bridge_test.go
+++ b/daemon/internal/hysteria2/bridge_test.go
@@ -74,14 +74,14 @@ func TestUDPBridgeRoundTripsThroughSocks(t *testing.T) {
 
 	// Point the bridge's fixed relay destination at our echo server for
 	// this test (production uses the package default, 127.0.0.1:51820).
-	old := relayDestination
-	relayDestination = "127.0.0.1:" + strconv.Itoa(echoPort)
-	defer func() { relayDestination = old }()
+	old := relayDestinationOverride
+	relayDestinationOverride = "127.0.0.1:" + strconv.Itoa(echoPort)
+	defer func() { relayDestinationOverride = old }()
 
 	logs := state.NewLogStore(100)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	bridge, err := newUDPBridge(ctx, logs, 0, mixedAddr)
+	bridge, err := newUDPBridge(ctx, logs, 0, mixedAddr, 0)
 	if err != nil {
 		t.Fatalf("newUDPBridge: %v", err)
 	}

--- a/daemon/internal/hysteria2/e2e_test.go
+++ b/daemon/internal/hysteria2/e2e_test.go
@@ -142,9 +142,9 @@ func TestE2EClientToServerRoundTrip(t *testing.T) {
 	// Server forwards to the echo listener regardless of what destination
 	// the client requests (route.Final defaults to the sole "direct"
 	// outbound), so point the bridge's fixed relay target at it.
-	old := relayDestination
-	relayDestination = net.JoinHostPort("127.0.0.1", strconv.Itoa(echoPort))
-	defer func() { relayDestination = old }()
+	old := relayDestinationOverride
+	relayDestinationOverride = net.JoinHostPort("127.0.0.1", strconv.Itoa(echoPort))
+	defer func() { relayDestinationOverride = old }()
 
 	profile := state.Hysteria2Profile{
 		LocalPort:    0,

--- a/daemon/internal/hysteria2/manager.go
+++ b/daemon/internal/hysteria2/manager.go
@@ -118,7 +118,7 @@ func (m *Manager) Start(ctx context.Context, profile state.Hysteria2Profile) err
 		}
 
 		mixedAddr := fmt.Sprintf("127.0.0.1:%d", mixedPort)
-		bridge, err = newUDPBridge(ctx, m.logs, profile.LocalPort, mixedAddr)
+		bridge, err = newUDPBridge(ctx, m.logs, profile.LocalPort, mixedAddr, profile.TargetPort)
 		if err != nil {
 			b.Close()
 			return fmt.Errorf("hysteria2: %w", err)
@@ -203,6 +203,7 @@ func (m *Manager) WaitForSession(ctx context.Context, timeout time.Duration) err
 	m.mu.RLock()
 	b := m.box
 	running := m.running && (m.bridge == nil || !m.bridge.isDead())
+	targetPort := m.profile.TargetPort
 	m.mu.RUnlock()
 	if !running || b == nil {
 		return fmt.Errorf("hysteria2: not running")
@@ -219,7 +220,7 @@ func (m *Manager) WaitForSession(ctx context.Context, timeout time.Duration) err
 	waitCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	target, err := net.ResolveUDPAddr("udp", relayDestination)
+	target, err := net.ResolveUDPAddr("udp", relayDestination(targetPort))
 	if err != nil {
 		return fmt.Errorf("hysteria2: resolve relay destination: %w", err)
 	}

--- a/daemon/internal/hysteria2/options.go
+++ b/daemon/internal/hysteria2/options.go
@@ -4,7 +4,9 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net"
 	"net/netip"
+	"strconv"
 	"strings"
 
 	C "github.com/sagernet/sing-box/constant"
@@ -20,16 +22,23 @@ const (
 	obfsTypeSalamander   = "salamander"
 )
 
-// relayDestination is the fixed SOCKS5 UDP ASSOCIATE destination the bridge
-// requests through the tunnel. It is intentionally not part of
-// state.Hysteria2Profile: same convention as Cloak (ProxyMethod=wireguard)
-// and NaiveProxy — the real WireGuard endpoint is a server-side deployment
-// detail, not client config. A correctly deployed Hysteria2 server either
-// runs WireGuard co-located on this loopback port (the common case, in
-// which this address is simply correct) or overrides the destination via
-// its own route config, ignoring whatever the client requests. Same-package
-// tests reassign this to point at a fixed test destination.
-var relayDestination = "127.0.0.1:51820"
+// relayDestinationOverride replaces the derived destination when set.
+// Same-package tests point it at a local echo server.
+var relayDestinationOverride string
+
+// relayDestination is the SOCKS5 UDP ASSOCIATE destination requested through
+// the tunnel: the remote node's own WireGuard listener, or the entry node's
+// loopback hop port when the profile is multihop. The node allowlists which
+// of these it will honour, so an unconfigured port is refused server-side.
+func relayDestination(targetPort int) string {
+	if relayDestinationOverride != "" {
+		return relayDestinationOverride
+	}
+	if targetPort <= 0 {
+		targetPort = state.DefaultWireGuardPort
+	}
+	return net.JoinHostPort("127.0.0.1", strconv.Itoa(targetPort))
+}
 
 func validateProfile(profile state.Hysteria2Profile) error {
 	if strings.TrimSpace(profile.RemoteHost) == "" {

--- a/daemon/internal/naive/manager.go
+++ b/daemon/internal/naive/manager.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -26,7 +27,16 @@ import (
 
 // The node-side bridge's fixed loopback address, reached via the
 // naive-server's SOCKS5 CONNECT once the TLS+HTTP2 tunnel is up.
-const bridgeAddr = "127.0.0.1:9000"
+// bridgeAddrFor is the node-side framed-UDP bridge this tunnel dials through
+// the CONNECT stream: one instance per exit under multihop, the default
+// otherwise. The node only listens on ports it generated, so an unconfigured
+// exit is refused there.
+func bridgeAddrFor(port int) string {
+	if port <= 0 {
+		port = state.DefaultNaiveBridgePort
+	}
+	return net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+}
 
 // Manager wraps the cgo-linked NaiveProxy engine behind transport.Manager,
 // owning the loopback UDP listener WireGuard's peer Endpoint points at.
@@ -208,14 +218,14 @@ func (m *Manager) Start(ctx context.Context, profile state.NaiveProfile) error {
 	pid := os.Getpid()
 	m.logs.Add(state.LogInfo, state.SourceNaive, fmt.Sprintf("in-process naive started (pid=%d) listening on 127.0.0.1:%d, engine socks=127.0.0.1:%d", pid, boundPort, st.SocksPort))
 
-	go m.runSession(sessionCtx, generation, udpConn, st.SocksPort, done, session)
+	go m.runSession(sessionCtx, generation, udpConn, st.SocksPort, bridgeAddrFor(profile.BridgePort), done, session)
 
 	return nil
 }
 
 // runSession dials the SOCKS5 CONNECT tunnel, then relays datagrams until
 // either side breaks. Runs for one Start/Stop cycle.
-func (m *Manager) runSession(sessionCtx context.Context, generation uint64, udpConn *net.UDPConn, socksPort int, done, session chan struct{}) {
+func (m *Manager) runSession(sessionCtx context.Context, generation uint64, udpConn *net.UDPConn, socksPort int, bridgeAddr string, done, session chan struct{}) {
 	defer close(done)
 
 	socksAddr := fmt.Sprintf("127.0.0.1:%d", socksPort)

--- a/daemon/internal/state/hop.go
+++ b/daemon/internal/state/hop.go
@@ -1,0 +1,126 @@
+package state
+
+import (
+	"errors"
+	"fmt"
+)
+
+var errSameRegion = errors.New("hop entryRegion and exitRegion must differ")
+
+func errHopIncomplete(field string) error {
+	return fmt.Errorf("hop is missing %s: a partial hop would egress at the entry node", field)
+}
+
+// DefaultCloakProxyMethod and DefaultNaiveBridgePort are the single-hop
+// targets: the node's own WireGuard listener, reached the way each protocol
+// names a destination.
+const (
+	DefaultCloakProxyMethod = "wireguard"
+	DefaultNaiveBridgePort  = 9000
+)
+
+// IsMultihop reports whether the transport terminates on an entry node
+// separate from the exit node holding the WireGuard peer.
+func (p Profile) IsMultihop() bool { return p.Hop != nil }
+
+// EntryRegion and ExitRegion label the session for status. Both are empty on
+// a single-hop profile, where one node is both.
+func (p Profile) EntryRegion() string {
+	if p.Hop == nil {
+		return ""
+	}
+	return p.Hop.EntryRegion
+}
+
+func (p Profile) ExitRegion() string {
+	if p.Hop == nil {
+		return ""
+	}
+	return p.Hop.ExitRegion
+}
+
+// ApplyHop returns a copy whose transport sub-profiles carry the destination
+// each should request on the remote node. Every transport goes through here,
+// so a new transport that forgets to call it fails closed at its default
+// rather than silently egressing at the entry.
+func ApplyHop(p Profile) Profile {
+	out := p
+
+	out.Cloak = p.Cloak
+	out.Cloak.ProxyMethod = cloakProxyMethod(p.Hop)
+
+	if p.Reality != nil {
+		reality := *p.Reality
+		reality.TargetPort = singBoxTargetPort(p.Hop)
+		out.Reality = &reality
+	}
+	if p.Hysteria2 != nil {
+		hysteria2 := *p.Hysteria2
+		hysteria2.TargetPort = singBoxTargetPort(p.Hop)
+		out.Hysteria2 = &hysteria2
+	}
+	if p.Shadowsocks != nil {
+		shadowsocks := *p.Shadowsocks
+		shadowsocks.TargetPort = singBoxTargetPort(p.Hop)
+		// The hop port is a loopback service on the entry, same as the local
+		// WireGuard listener it replaces.
+		shadowsocks.TargetHost = loopbackHost
+		out.Shadowsocks = &shadowsocks
+	}
+	if p.Naive != nil {
+		naive := *p.Naive
+		naive.BridgePort = naiveBridgePort(p.Hop)
+		out.Naive = &naive
+	}
+
+	return out
+}
+
+const loopbackHost = "127.0.0.1"
+
+func singBoxTargetPort(hop *HopProfile) int {
+	if hop != nil && hop.SingBoxPort > 0 {
+		return hop.SingBoxPort
+	}
+	return DefaultWireGuardPort
+}
+
+func cloakProxyMethod(hop *HopProfile) string {
+	if hop != nil && hop.CloakProxyMethod != "" {
+		return hop.CloakProxyMethod
+	}
+	return DefaultCloakProxyMethod
+}
+
+func naiveBridgePort(hop *HopProfile) int {
+	if hop != nil && hop.NaiveBridgePort > 0 {
+		return hop.NaiveBridgePort
+	}
+	return DefaultNaiveBridgePort
+}
+
+// ValidateHop rejects a hop the hub did not fully specify. A partially
+// specified hop is the dangerous case: transports without a selector would
+// fall back to their defaults and egress at the entry node, which is exactly
+// the multihop guarantee the user asked for being silently dropped.
+func ValidateHop(p Profile) error {
+	if p.Hop == nil {
+		return nil
+	}
+	if p.Hop.SingBoxPort <= 0 {
+		return errHopIncomplete("singBoxPort")
+	}
+	if p.Hop.CloakProxyMethod == "" {
+		return errHopIncomplete("cloakProxyMethod")
+	}
+	if p.Naive != nil && p.Hop.NaiveBridgePort <= 0 {
+		return errHopIncomplete("naiveBridgePort")
+	}
+	if p.Hop.EntryRegion == "" || p.Hop.ExitRegion == "" {
+		return errHopIncomplete("entryRegion/exitRegion")
+	}
+	if p.Hop.EntryRegion == p.Hop.ExitRegion {
+		return errSameRegion
+	}
+	return nil
+}

--- a/daemon/internal/state/hop_test.go
+++ b/daemon/internal/state/hop_test.go
@@ -1,0 +1,147 @@
+package state
+
+import "testing"
+
+func fullProfile() Profile {
+	return Profile{
+		ID:          "auto-eu-west-1",
+		Cloak:       CloakProfile{RemoteHost: "192.0.2.10", RemotePort: 443},
+		Naive:       &NaiveProfile{RemoteHost: "naive.example", RemotePort: 8443},
+		Reality:     &RealityProfile{RemoteHost: "192.0.2.10", RemotePort: 8444},
+		Hysteria2:   &Hysteria2Profile{RemoteHost: "192.0.2.10", RemotePort: 443},
+		Shadowsocks: &ShadowsocksProfile{RemoteHost: "192.0.2.10", RemotePort: 8488},
+	}
+}
+
+// A single-hop profile must resolve to exactly the destinations the daemon
+// used before multihop existed. This is the regression guard for every
+// existing user: if it fails, shipping multihop changed single-hop routing.
+func TestApplyHopSingleHopKeepsTodaysTargets(t *testing.T) {
+	got := ApplyHop(fullProfile())
+
+	if got.Cloak.ProxyMethod != "wireguard" {
+		t.Errorf("cloak proxyMethod = %q, want wireguard", got.Cloak.ProxyMethod)
+	}
+	if got.Reality.TargetPort != 51820 {
+		t.Errorf("reality targetPort = %d, want 51820", got.Reality.TargetPort)
+	}
+	if got.Hysteria2.TargetPort != 51820 {
+		t.Errorf("hysteria2 targetPort = %d, want 51820", got.Hysteria2.TargetPort)
+	}
+	if got.Shadowsocks.TargetPort != 51820 {
+		t.Errorf("shadowsocks targetPort = %d, want 51820", got.Shadowsocks.TargetPort)
+	}
+	if got.Naive.BridgePort != 9000 {
+		t.Errorf("naive bridgePort = %d, want 9000", got.Naive.BridgePort)
+	}
+	if got.IsMultihop() {
+		t.Error("IsMultihop() = true for a profile with no hop")
+	}
+}
+
+func TestApplyHopRoutesEveryTransportToTheEntryHopPort(t *testing.T) {
+	profile := fullProfile()
+	profile.Hop = &HopProfile{
+		SingBoxPort:      51831,
+		CloakProxyMethod: "wireguard-via-us-east-1",
+		NaiveBridgePort:  9002,
+		EntryRegion:      "eu-west-1",
+		ExitRegion:       "us-east-1",
+	}
+
+	got := ApplyHop(profile)
+
+	if got.Cloak.ProxyMethod != "wireguard-via-us-east-1" {
+		t.Errorf("cloak proxyMethod = %q", got.Cloak.ProxyMethod)
+	}
+	for name, port := range map[string]int{
+		"reality":     got.Reality.TargetPort,
+		"hysteria2":   got.Hysteria2.TargetPort,
+		"shadowsocks": got.Shadowsocks.TargetPort,
+	} {
+		if port != 51831 {
+			t.Errorf("%s targetPort = %d, want 51831", name, port)
+		}
+	}
+	if got.Naive.BridgePort != 9002 {
+		t.Errorf("naive bridgePort = %d, want 9002", got.Naive.BridgePort)
+	}
+	// Shadowsocks is the one transport carrying a target *host*; the hop port
+	// is a loopback service on the entry, never the exit's public address.
+	if got.Shadowsocks.TargetHost != "127.0.0.1" {
+		t.Errorf("shadowsocks targetHost = %q, want 127.0.0.1", got.Shadowsocks.TargetHost)
+	}
+	if !got.IsMultihop() || got.EntryRegion() != "eu-west-1" || got.ExitRegion() != "us-east-1" {
+		t.Errorf("hop labels not surfaced: %v/%v", got.EntryRegion(), got.ExitRegion())
+	}
+}
+
+// ApplyHop must not write through the caller's pointers: the stored config is
+// shared, and a mutated copy would leak one session's hop into the next.
+func TestApplyHopDoesNotMutateInput(t *testing.T) {
+	profile := fullProfile()
+	profile.Hop = &HopProfile{
+		SingBoxPort: 51831, CloakProxyMethod: "wireguard-via-x",
+		NaiveBridgePort: 9002, EntryRegion: "a", ExitRegion: "b",
+	}
+
+	_ = ApplyHop(profile)
+
+	if profile.Reality.TargetPort != 0 || profile.Hysteria2.TargetPort != 0 ||
+		profile.Shadowsocks.TargetPort != 0 || profile.Naive.BridgePort != 0 ||
+		profile.Cloak.ProxyMethod != "" {
+		t.Error("ApplyHop mutated the profile it was given")
+	}
+}
+
+// A hop missing any selector would leave that transport on its default and
+// egress at the entry node — the guarantee silently dropped. Reject instead.
+func TestValidateHopRejectsPartialHops(t *testing.T) {
+	complete := HopProfile{
+		SingBoxPort: 51831, CloakProxyMethod: "wireguard-via-x",
+		NaiveBridgePort: 9002, EntryRegion: "a", ExitRegion: "b",
+	}
+
+	tests := map[string]func(*HopProfile){
+		"no singBoxPort":      func(h *HopProfile) { h.SingBoxPort = 0 },
+		"no cloakProxyMethod": func(h *HopProfile) { h.CloakProxyMethod = "" },
+		"no naiveBridgePort":  func(h *HopProfile) { h.NaiveBridgePort = 0 },
+		"no entryRegion":      func(h *HopProfile) { h.EntryRegion = "" },
+		"no exitRegion":       func(h *HopProfile) { h.ExitRegion = "" },
+		"same region":         func(h *HopProfile) { h.ExitRegion = h.EntryRegion },
+	}
+
+	for name, breakIt := range tests {
+		t.Run(name, func(t *testing.T) {
+			hop := complete
+			breakIt(&hop)
+			profile := fullProfile()
+			profile.Hop = &hop
+			if err := ValidateHop(profile); err == nil {
+				t.Fatal("ValidateHop accepted an incomplete hop")
+			}
+		})
+	}
+
+	profile := fullProfile()
+	profile.Hop = &complete
+	if err := ValidateHop(profile); err != nil {
+		t.Fatalf("ValidateHop rejected a complete hop: %v", err)
+	}
+	if err := ValidateHop(fullProfile()); err != nil {
+		t.Fatalf("ValidateHop rejected a single-hop profile: %v", err)
+	}
+}
+
+// naiveBridgePort is only required when the profile actually has naive.
+func TestValidateHopIgnoresNaiveBridgePortWithoutNaive(t *testing.T) {
+	profile := fullProfile()
+	profile.Naive = nil
+	profile.Hop = &HopProfile{
+		SingBoxPort: 51831, CloakProxyMethod: "wireguard-via-x",
+		EntryRegion: "a", ExitRegion: "b",
+	}
+	if err := ValidateHop(profile); err != nil {
+		t.Fatalf("ValidateHop required naiveBridgePort with no naive profile: %v", err)
+	}
+}

--- a/daemon/internal/state/types.go
+++ b/daemon/internal/state/types.go
@@ -101,6 +101,9 @@ type CloakProfile struct {
 	Password         string `json:"password"`
 	// Cover SNI Cloak presents; empty => buildRawConfig defaults to www.microsoft.com.
 	ServerName string `json:"serverName,omitempty"`
+	// ProxyMethod is the server-side ProxyBook key naming where decoded
+	// traffic goes. Empty => DefaultCloakProxyMethod. Set by ApplyHop.
+	ProxyMethod string `json:"proxyMethod,omitempty"`
 }
 
 // NaiveProfile carries per-device NaiveProxy credentials, hub-provisioned
@@ -115,6 +118,9 @@ type NaiveProfile struct {
 	// ServerName is the cover SNI presented during the TLS handshake
 	// (naive's --proxy host), analogous to CloakProfile.ServerName.
 	ServerName string `json:"serverName,omitempty"`
+	// BridgePort is the remote node's framed-UDP bridge this tunnel dials
+	// through the CONNECT stream. Zero => DefaultNaiveBridgePort. Set by ApplyHop.
+	BridgePort int `json:"bridgePort,omitempty"`
 }
 
 // RealityProfile carries per-device VLESS+REALITY credentials, hub-provisioned
@@ -164,6 +170,9 @@ type Hysteria2Profile struct {
 	// PinSHA256 is a base64-encoded SHA-256 hash of the server certificate's
 	// public key; when set, the cert is pinned regardless of Insecure.
 	PinSHA256 string `json:"pinSha256,omitempty"`
+	// TargetPort is the loopback port on the remote node that decoded UDP is
+	// forwarded to. Zero => DefaultWireGuardPort. Set by ApplyHop.
+	TargetPort int `json:"targetPort,omitempty"`
 }
 
 // ShadowsocksProfile carries per-node Shadowsocks (AEAD or SS-2022) settings.
@@ -222,10 +231,35 @@ type WireGuardProfile struct {
 	DirectEndpoint string `json:"directEndpoint,omitempty"`
 }
 
+// DefaultWireGuardPort is where a node's own WireGuard listener sits, and so
+// where every transport forwards decoded traffic on a single-hop profile.
+const DefaultWireGuardPort = 51820
+
+// HopProfile makes a profile multihop: the transport terminates on an entry
+// node that relays WireGuard on to the exit node holding the peer. Nil means
+// single-hop. Selectors differ because the wire protocols do — Cloak names a
+// ProxyBook key, sing-box a destination port, naive a bridge port — and each
+// is issued by the hub, never derived client-side from a node ordering.
+type HopProfile struct {
+	// SingBoxPort is the entry's loopback hop port for REALITY, Hysteria2
+	// and Shadowsocks.
+	SingBoxPort int `json:"singBoxPort"`
+	// CloakProxyMethod is the entry's ProxyBook key routing to this exit.
+	CloakProxyMethod string `json:"cloakProxyMethod,omitempty"`
+	// NaiveBridgePort is the entry's framed-UDP bridge for this exit.
+	NaiveBridgePort int `json:"naiveBridgePort,omitempty"`
+	// EntryRegion and ExitRegion label the session for the UI. Display only;
+	// routing never reads them.
+	EntryRegion string `json:"entryRegion,omitempty"`
+	ExitRegion  string `json:"exitRegion,omitempty"`
+}
+
 type Profile struct {
 	ID    string       `json:"id"`
 	Name  string       `json:"name"`
 	Cloak CloakProfile `json:"cloak"`
+	// Hop is optional; nil means single-hop. See HopProfile.
+	Hop *HopProfile `json:"hop,omitempty"`
 	// Naive is optional; nil means this profile has no NaiveProxy fallback
 	// configured and Connect only ever tries Cloak.
 	Naive *NaiveProfile `json:"naive,omitempty"`

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -103,10 +103,25 @@ export const WireGuardProfileSchema = z.object({
   directEndpoint: z.string().optional()
 });
 
+/**
+ * Present only on a multihop profile: the transport terminates on an entry
+ * node that relays WireGuard to the exit node holding the peer. The selectors
+ * differ because the wire protocols do, and every one is issued by the hub —
+ * the client never derives them from a node ordering it should not know.
+ */
+export const HopProfileSchema = z.object({
+  singBoxPort: z.number().int().positive(),
+  cloakProxyMethod: z.string().min(1),
+  naiveBridgePort: z.number().int().positive().optional(),
+  entryRegion: z.string().min(1),
+  exitRegion: z.string().min(1)
+});
+
 export const ProfileSchema = z.object({
   id: z.string().min(1),
   name: z.string().min(1),
   cloak: CloakProfileSchema,
+  hop: HopProfileSchema.optional(),
   /**
    * Every transport endpoint of this profile's node as a raw IP, straight from
    * the hub. The daemon permits these through the kill switch and routes them


### PR DESCRIPTION
## Multihop: entry/exit node separation (desktop + daemon)

Now based on `master` (unstacked from `android`); desktop only.

A profile is assembled from two sources that until now always described the same node: `/api/register` gives the WireGuard peer, `/api/client/regions` gives the transport credentials. Multihop takes the peer from the **exit** and the credentials from the **entry**. The entry forwards the same WireGuard datagram it already unwraps to the exit, so MTU is unchanged and there is no new cryptography. Only the client-to-entry hop needs disguising; entry-to-exit is plain WireGuard between our own hosts.

### Daemon
- `state.HopProfile` carries the hop; nil is single-hop. `ApplyHop` resolves every transport's destination in one place (sing-box target port, Cloak ProxyBook key, naive bridge port), so a transport that forgets it fails closed at its own default rather than egressing at the entry.
- `ValidateHop` rejects a partially specified hop, and a hop profile that carries a direct WireGuard endpoint (the direct method would bypass the entry).
- `ApplyHop` drops Snowflake under a hop: it has no selector and would egress at the entry.

### Desktop
- `provision(serverId, signal, entryServerId)`: transports dial the entry, the peer comes from the exit. Under a hop the exit's address never reaches `excludeIPs`, the kill-switch permits or `directEndpoint`. If the hub answers without a `hop` block the connect fails with "multi-hop isn't available yet" instead of silently connecting single-hop.
- `multihopEntryId` setting (settings.json) with IPC get/set. The entry is filtered out of the exit candidates and the tray plan; the reuse fingerprint includes it; a pinned "WireGuard (no disguise)" is treated as auto while multi-hop is on.
- UI: a multi-hop button on the hero beside the switch-server button, and the same control at the top of the region selector. Both open an overlay listing "Off" and the entries the hub flags `multihop`. The hero shows "Exit region" and "via <entry>" while on. No Settings section. All 8 locales.

### Hub contract (PangeaHubServer `feature/multihop`)
- `/api/client/regions` items carry `multihop: true` on nodes deployed with hop relays; only those are offered as entries.
- `/api/register` + `entryRegion` returns `hop: {singBoxPort, cloakProxyMethod, naiveBridgePort, entryRegion, exitRegion}`, transport blocks for the entry, and no `serverEndpoint`.
- Ports: `singBoxPort = 51830 + i`, `naiveBridgePort = 9100 + i`, `cloakProxyMethod = wireguard-via-<exit>`, `i` = index in the full `nodes.json`.

### Tests
- Go: single-hop parity, leak guards (exit never in permits or bypass list, peer endpoint stays loopback), partial-hop rejection, direct-endpoint rejection, Snowflake drop, immutability.
- Desktop: shared multi-hop helpers, fingerprint, cached-server validation, renderer entry resolution. `npm test -w @pangeavpn/desktop`: 399 pass.

### Rollout order
Nodes first (`HOP_TARGETS` from `hub/scripts/print-hop-targets.js`), verify listeners, flag `multihop: true` per node, deploy hub, then ship this client. See `docs/multihop.md` in PangeaHubServer. Node-side forwarding was validated locally with `sing-box check` and a live UDP relay through a generated hop listener; the first on-fleet check is `tcpdump` on an exit showing only the entry's address as source.
